### PR TITLE
에이전트 그룹 관리 뷰 구현

### DIFF
--- a/src/main/java/com/agencyplatformclonecoding/controller/AgentGroupController.java
+++ b/src/main/java/com/agencyplatformclonecoding/controller/AgentGroupController.java
@@ -1,4 +1,41 @@
 package com.agencyplatformclonecoding.controller;
 
+import com.agencyplatformclonecoding.service.AgentGroupService;
+import com.agencyplatformclonecoding.service.AgentService;
+import com.agencyplatformclonecoding.service.PaginationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/agentGroups")
+@Controller
 public class AgentGroupController {
+
+    private final AgentGroupService agentGroupService;
+    private final PaginationService paginationService;
+
+    @GetMapping
+    public String agentGroups(ModelMap map) {
+        map.addAttribute("agentGroups", List.of());
+        return "agentgroups/index";
+    }
+
+    @GetMapping("/{agentGroupId}")
+    public String agentGroup(@PathVariable String agentGroupId, ModelMap map) {
+        map.addAttribute("agentGroup", "agentGroup"); // TODO : 실제 데이터 구현 시 여기에 넣어야 함
+        map.addAttribute("agents", List.of());
+         return "agentgroups/detail";
+    }
+
+    @GetMapping("/{agentGroupId}/{agentId}")
+        public String selectAgent(@PathVariable String agentGroupId, String agentId) {
+             return "forward:/agents/{agentId}";
+         }
+
 }

--- a/src/main/java/com/agencyplatformclonecoding/service/AgentGroupService.java
+++ b/src/main/java/com/agencyplatformclonecoding/service/AgentGroupService.java
@@ -1,4 +1,20 @@
 package com.agencyplatformclonecoding.service;
 
+import com.agencyplatformclonecoding.repository.AgentGroupRepository;
+import com.agencyplatformclonecoding.repository.AgentRepository;
+import com.agencyplatformclonecoding.repository.ClientUserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
 public class AgentGroupService {
+
+    private final AgentRepository agentRepository;
+    private final AgentGroupRepository agentGroupRepository;
+
 }

--- a/src/main/resources/templates/agentgroups/detail.html
+++ b/src/main/resources/templates/agentgroups/detail.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/main/resources/templates/agentgroups/form.html
+++ b/src/main/resources/templates/agentgroups/form.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/main/resources/templates/agentgroups/index.html
+++ b/src/main/resources/templates/agentgroups/index.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="">
+  <meta name="author" content="mrcocoball">
+  <title>에이전트 그룹 리스트</title>
+
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+  <link href="/css/search-bar.css" rel="stylesheet">
+  <link href="/css/articles/table-header.css" rel="stylesheet">
+</head>
+
+<body>
+
+  <header id="header">
+    헤더 삽입부
+    <hr>
+  </header>
+
+  <main class="d-flex flex-nowrap">
+    <div class="d-flex flex-column flex-shrink-0 p-3 text-bg-dark" style="width: 280px;, height: 100%;">
+      <a href="/" class="d-flex align-items-center mb-3 mb-md-0 me-md-auto text-white text-decoration-none">
+        <svg class="bi pe-none me-2" width="40" height="32"><use xlink:href="#bootstrap"/></svg>
+        <span class="fs-4"></span>
+      </a>
+      <ul class="nav nav-pills flex-column mb-auto">
+        <li class="nav-item">
+          <a href="#" class="nav-link text-white">
+            <svg class="bi pe-none me-2" width="16" height="16"><use xlink:href="#home"/></svg>
+            에이전트 관리
+          </a>
+        </li>
+        <li>
+          <a href="#" class="nav-link active" aria-current="page">
+            <svg class="bi pe-none me-2" width="16" height="16"><use xlink:href="#speedometer2"/></svg>
+            에이전트 그룹 관리
+          </a>
+        </li>
+        <li>
+          <a href="#" class="nav-link text-white">
+            <svg class="bi pe-none me-2" width="16" height="16"><use xlink:href="#table"/></svg>
+            광고주 관리
+          </a>
+        </li>
+        <li>
+          <a href="#" class="nav-link text-white">
+            <svg class="bi pe-none me-2" width="16" height="16"><use xlink:href="#grid"/></svg>
+            광고 관리
+          </a>
+        </li>
+        <li>
+          <a href="#" class="nav-link text-white">
+            <svg class="bi pe-none me-2" width="16" height="16"><use xlink:href="#people-circle"/></svg>
+            대시보드
+          </a>
+        </li>
+    </div>
+
+   <div class="container">
+   <h1> 에이전트 그룹 관리 페이지 </h1>
+    <div class="row">
+      <div class="card card-margin search-form">
+        <div class="card-body p-0">
+          <form action="/agents" method="get">
+            <div class="row">
+              <div class="col-12">
+                <div class="row no-gutters">
+                  <div class="col-lg-3 col-md-3 col-sm-12 p-0">
+                    <label for="search-type" hidden>검색 유형</label>
+                    <select class="form-control" id="search-type" name="searchType">
+                      <option>에이전트 그룹 ID</option>
+                      <option>에이전트 그룹 이름</option>
+                    </select>
+                  </div>
+                  <div class="col-lg-8 col-md-6 col-sm-12 p-0">
+                    <label for="search-value" hidden>검색어</label>
+                    <input type="text" placeholder="검색어..." class="form-control" id="search-value" name="searchValue">
+                  </div>
+                  <div class="col-lg-1 col-md-3 col-sm-12 p-0">
+                    <button type="submit" class="btn btn-base">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-search">
+                        <circle cx="11" cy="11" r="8"></circle>
+                        <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="d-grid gap-2 d-md-flex justify-content-md">
+        <a class="btn btn-primary me-md-2" role="button" id="write-article">에이전트 그룹 생성</a>
+      </div>
+    </div>
+
+    <div class="row">
+      <table class="table" id="client-table">
+        <thead>
+        <tr>
+          <th class="user-id col-2"><a>ID</a></th>
+          <th class="nickname col-2"><a>그룹명</a></th>
+          <th class="created-at col"><a>그룹 생성일</a></th>
+          <th class="profile col-2"><a>소속 에이전트 확인</a></th>
+          <th class="headcount col-2"><a>소속 인원 수</a></th>
+          <th class="button"><a></a></th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <td class="user-id"><a>team01</a></td>
+          <td class="nickname">마케팅 1팀</td>
+          <td class="clients"><time>2022-08-18</time></td>
+          <td class="profile">소속 에이전트 확인</td>
+          <td class="headcount">3</td>
+          <td class="button"><a class="btn btn-danger me-md-2" role="button" id="agent-delete">삭제</a></td>
+        </tr>
+        <tr>
+          <td>team02</td>
+          <td>마케팅 2팀</td>
+          <td>2022-08-19</td>
+          <td class="profile">소속 에이전트 확인</td>
+          <td class="headcount">2</td>
+          <td class="button"><a class="btn btn-danger me-md-2" role="button" id="agent-delete">삭제</a></td>
+        </tr>
+        <tr>
+          <td>team03</td>
+          <td>마케팅 3팀</td>
+          <td>2022-08-20</td>
+          <td class="profile">소속 에이전트 확인</td>
+          <td class="headcount">5</td>
+          <td class="button"><a class="btn btn-danger me-md-2" role="button" id="agent-delete">삭제</a></td>
+        </tr>
+        <tr>
+          <td>team04</td>
+          <td>마케팅 5팀</td>
+          <td>2022-08-20</td>
+          <td class="profile">소속 에이전트 확인</td>
+          <td class="headcount">2</td>
+          <td class="button"><a class="btn btn-danger me-md-2" role="button" id="agent-delete">삭제</a></td>
+        </tr>
+        <tr>
+          <td>team05</td>
+          <td>마케팅 본부</td>
+          <td>2022-08-20</td>
+          <td class="profile">소속 에이전트 확인</td>
+          <td class="headcount">8</td>
+          <td class="button"><a class="btn btn-danger me-md-2" role="button" id="agent-delete">삭제</a></td>
+        </tr>
+      </tbody>
+    </table>
+    </div>
+
+    <div class="row">
+      <nav id="pagination" aria-label="Page navigation">
+        <ul class="pagination justify-content-center">
+          <li class="page-item"><a class="page-link" href="#">Previous</a></li>
+          <li class="page-item"><a class="page-link" href="#">1</a></li>
+          <li class="page-item"><a class="page-link" href="#">Next</a></li>
+        </ul>
+      </nav>
+    </div>
+
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-A3rJD856KowSb7dwlZdYEkO39Gagi7vIsF0jrRAoQmDKKtQBHUuLZ9AsSv4jD4Xa" crossorigin="anonymous"></script>
+
+</body>

--- a/src/test/java/com/agencyplatformclonecoding/controller/AgentGroupControllerTest.java
+++ b/src/test/java/com/agencyplatformclonecoding/controller/AgentGroupControllerTest.java
@@ -1,5 +1,6 @@
 package com.agencyplatformclonecoding.controller;
 
+import com.agencyplatformclonecoding.config.SecurityConfig;
 import com.agencyplatformclonecoding.service.AgentGroupService;
 import com.agencyplatformclonecoding.service.AgentService;
 import com.agencyplatformclonecoding.service.PaginationService;
@@ -9,16 +10,18 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 
-@Disabled("구현 중")
 @DisplayName("VIEW 컨트롤러 - 에이전트 그룹 관리")
+@Import(SecurityConfig.class)
 @WebMvcTest(AgentGroupController.class)
 class AgentGroupControllerTest {
 
@@ -36,7 +39,6 @@ class AgentGroupControllerTest {
         this.mvc = mvc;
     }
 
-    //@Disabled("구현 중")
     @DisplayName("[VIEW][GET] 에이전트 그룹 리스트 - 정상 호출")
     @Test
     public void givenNothing_whenRequestingAgentGroupsView_thenReturnsAgentGroupsView() throws Exception {
@@ -46,11 +48,10 @@ class AgentGroupControllerTest {
         mvc.perform(get("/agentGroups"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(view().name("agentGroups/index"))
+                .andExpect(view().name("agentgroups/index"))
                 .andExpect(model().attributeExists("agentGroups"));
     }
 
-    //@Disabled("구현 중")
     @DisplayName("[VIEW][GET] 에이전트 그룹 상세 정보 - 정상 호출")
     @Test
     public void givenNothing_whenRequestingAgentGroupDetailView_thenReturnsAgentGroupDetailView() throws Exception {
@@ -60,8 +61,22 @@ class AgentGroupControllerTest {
         mvc.perform(get("/agentGroups/mkt1"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(view().name("agentGroups/detail"))
-                .andExpect(model().attributeExists("agentGroup"));
+                .andExpect(view().name("agentgroups/detail"))
+                .andExpect(model().attributeExists("agentGroup"))
+                .andExpect(model().attributeExists("agents"));
+    }
+
+    @DisplayName("[VIEW][GET] 에이전트 그룹 상세 정보 -> 해당 에이전트 관리 페이지로 리다이렉션")
+    @Test
+    void givenNothing_whenRequestingAgentView_thenRedirectsToAgentView() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/agentGroups/agentGroupId/agnetId"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("forward:/agents/{agentId}"))
+                .andExpect(forwardedUrl("/agents/{agentId}"))
+                .andDo(MockMvcResultHandlers.print());
     }
 
 }


### PR DESCRIPTION
에이전트 그룹 관리 페이지를 구현한다
* [x] 뷰 엔드포인트 테스트
  * [x] 에이전트 그룹 리스트
  * [x] 에이전트 그룹 상세 페이지
* [x] 에이전트 그룹 관리 기능 임시 구현 (핸들러 메소드 생성만 하고 테스트 통과하게끔)
  * [x] 에이전트 그룹 리스트 조회
  * [x] 에이전트 그룹 상세 정보 조회 (이름, 프로필, 소속된 에이전트)
  * [x] 에이전트 그룹 상세 정보 - 소속된 에이전트 조회 (에이전트 관리 상세 페이지로 리다이렉션)
* [x] 페이지 구현
* [x] 디자인 1차 작업

This closes #18 