### PR TITLE
광고 관리 (광고주 + 캠페인) 뷰 구현

### DIFF
--- a/src/main/java/com/agencyplatformclonecoding/config/ThymeleafConfig.java
+++ b/src/main/java/com/agencyplatformclonecoding/config/ThymeleafConfig.java
@@ -1,0 +1,32 @@
+package com.agencyplatformclonecoding.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.thymeleaf.spring5.templateresolver.SpringResourceTemplateResolver;
+
+@Configuration
+public class ThymeleafConfig {
+
+    @Bean
+    public SpringResourceTemplateResolver thymeleafTemplateResolver(
+            SpringResourceTemplateResolver defaultTemplateResolver,
+            Thymeleaf3Properties thymeleaf3Properties
+    ) {
+        defaultTemplateResolver.setUseDecoupledLogic(thymeleaf3Properties.isDecoupledLogic());
+
+        return defaultTemplateResolver;
+    }
+
+    @RequiredArgsConstructor
+    @Getter
+    @ConstructorBinding
+    @ConfigurationProperties("spring.thymeleaf3")
+    public static class Thymeleaf3Properties {
+        private final boolean decoupledLogic;
+
+    }
+}

--- a/src/main/java/com/agencyplatformclonecoding/controller/ManageController.java
+++ b/src/main/java/com/agencyplatformclonecoding/controller/ManageController.java
@@ -1,4 +1,52 @@
 package com.agencyplatformclonecoding.controller;
 
+import com.agencyplatformclonecoding.service.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("manage")
+@Controller
 public class ManageController {
+
+    private final ManageService manageService;
+    private final CampaignService campaignService;
+    private final CreativeService creativeService;
+    private final PaginationService paginationService;
+
+    @GetMapping
+    public String manage(ModelMap map) {
+        map.addAttribute("manage", List.of());
+        return "manage/index";
+    }
+
+    @GetMapping("/{clientId}")
+     public String manageClient(@PathVariable String clientId, ModelMap map) {
+        map.addAttribute("clientId", "clientId"); // TODO : 실제 데이터 구현 시 여기에 넣어야 함
+        map.addAttribute("campaigns", List.of());
+         return "manage/client";
+     }
+
+    @GetMapping("/{clientId}/{campaignId}")
+     public String manageClientsCampaign(@PathVariable String clientId, Long campaignId, ModelMap map) {
+        map.addAttribute("clientId", "clientId"); // TODO : 실제 데이터 구현 시 여기에 넣어야 함
+        map.addAttribute("campaignId", "campaignId");
+        map.addAttribute("creatives", List.of());
+         return "manage/campaign";
+     }
+
+    @GetMapping("/{clientId}/{campaignId}/{creativeId}")
+     public String manageClientsCreative(@PathVariable String clientId, Long campaignId, Long creativeId, ModelMap map) {
+        map.addAttribute("clientId", "clientId"); // TODO : 실제 데이터 구현 시 여기에 넣어야 함
+        map.addAttribute("campaignId", "campaignId");
+        map.addAttribute("creativeId", "creativeId");
+         return "manage/creative";
+     }
+
 }

--- a/src/main/java/com/agencyplatformclonecoding/service/CampaignService.java
+++ b/src/main/java/com/agencyplatformclonecoding/service/CampaignService.java
@@ -1,4 +1,19 @@
 package com.agencyplatformclonecoding.service;
 
+import com.agencyplatformclonecoding.repository.ClientUserRepository;
+import com.agencyplatformclonecoding.repository.CreativeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
 public class CampaignService {
+
+    private final ClientUserRepository clientUserRepository;
+    private final CreativeRepository creativeRepository;
+
 }

--- a/src/main/java/com/agencyplatformclonecoding/service/CreativeService.java
+++ b/src/main/java/com/agencyplatformclonecoding/service/CreativeService.java
@@ -1,4 +1,19 @@
 package com.agencyplatformclonecoding.service;
 
+import com.agencyplatformclonecoding.repository.CampaignRepository;
+import com.agencyplatformclonecoding.repository.CreativeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
 public class CreativeService {
+
+    private final CampaignRepository campaignRepository;
+    private final CreativeRepository creativeRepository;
+
 }

--- a/src/main/java/com/agencyplatformclonecoding/service/ManageService.java
+++ b/src/main/java/com/agencyplatformclonecoding/service/ManageService.java
@@ -1,4 +1,23 @@
 package com.agencyplatformclonecoding.service;
 
+import com.agencyplatformclonecoding.repository.AgentRepository;
+import com.agencyplatformclonecoding.repository.CampaignRepository;
+import com.agencyplatformclonecoding.repository.ClientUserRepository;
+import com.agencyplatformclonecoding.repository.CreativeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
 public class ManageService {
+
+    private final AgentRepository agentRepository;
+    private final ClientUserRepository clientUserRepository;
+    private final CampaignRepository campaignRepository;
+    private final CreativeRepository creativeRepository;
+
 }

--- a/src/main/java/com/agencyplatformclonecoding/service/PaginationService.java
+++ b/src/main/java/com/agencyplatformclonecoding/service/PaginationService.java
@@ -1,4 +1,7 @@
 package com.agencyplatformclonecoding.service;
 
+import org.springframework.stereotype.Service;
+
+@Service
 public class PaginationService {
 }

--- a/src/main/resources/templates/agentgroups/index.th.xml
+++ b/src/main/resources/templates/agentgroups/index.th.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<thlogic>
+  <attr sel="#header" th:replace="header :: header" />
+</thlogic>

--- a/src/main/resources/templates/agents/index.th.xml
+++ b/src/main/resources/templates/agents/index.th.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<thlogic>
+  <attr sel="#header" th:replace="header :: header" />
+</thlogic>

--- a/src/main/resources/templates/clients/index.th.xml
+++ b/src/main/resources/templates/clients/index.th.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<thlogic>
+  <attr sel="#header" th:replace="header :: header" />
+</thlogic>

--- a/src/main/resources/templates/manage/campaign.html
+++ b/src/main/resources/templates/manage/campaign.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/main/resources/templates/manage/client.html
+++ b/src/main/resources/templates/manage/client.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/main/resources/templates/manage/creative.html
+++ b/src/main/resources/templates/manage/creative.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/main/resources/templates/manage/index.html
+++ b/src/main/resources/templates/manage/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/main/resources/templates/manage/index.th.xml
+++ b/src/main/resources/templates/manage/index.th.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<thlogic>
+  <attr sel="#header" th:replace="header :: header" />
+</thlogic>

--- a/src/test/java/com/agencyplatformclonecoding/controller/ManageControllerTest.java
+++ b/src/test/java/com/agencyplatformclonecoding/controller/ManageControllerTest.java
@@ -1,5 +1,8 @@
 package com.agencyplatformclonecoding.controller;
 
+import com.agencyplatformclonecoding.config.SecurityConfig;
+import com.agencyplatformclonecoding.service.CampaignService;
+import com.agencyplatformclonecoding.service.CreativeService;
 import com.agencyplatformclonecoding.service.ManageService;
 import com.agencyplatformclonecoding.service.PaginationService;
 import org.junit.jupiter.api.Disabled;
@@ -8,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -15,8 +19,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 
-@Disabled("구현 중")
 @DisplayName("VIEW 컨트롤러 - 광고주 관리")
+@Import(SecurityConfig.class)
 @WebMvcTest(ManageController.class)
 class ManageControllerTest {
 
@@ -27,6 +31,12 @@ class ManageControllerTest {
 
     @MockBean
     private PaginationService paginationService;
+
+    @MockBean
+    private CampaignService campaignService;
+
+    @MockBean
+    private CreativeService creativeService;
 
     public ManageControllerTest(
             @Autowired MockMvc mvc
@@ -55,11 +65,12 @@ class ManageControllerTest {
         // Given : 추후 구현
 
         // When & Then
-        mvc.perform(get("/manage/c1"))
+        mvc.perform(get("/manage/clientId"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(view().name("manage/c1"))
-                .andExpect(model().attributeExists("manage/client"));
+                .andExpect(view().name("manage/client"))
+                .andExpect(model().attributeExists("clientId"))
+                .andExpect(model().attributeExists("campaigns"));
     }
 
     //@Disabled("구현 중")
@@ -69,11 +80,13 @@ class ManageControllerTest {
         // Given : 추후 구현
 
         // When & Then
-        mvc.perform(get("/manage/c1/1"))
+        mvc.perform(get("/manage/clientId/campaignId"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(view().name("manage/c1/1"))
-                .andExpect(model().attributeExists("manage/client/campaign"));
+                .andExpect(view().name("manage/campaign"))
+                .andExpect(model().attributeExists("clientId"))
+                .andExpect(model().attributeExists("campaignId"))
+                .andExpect(model().attributeExists("creatives"));
     }
 
     //@Disabled("구현 중")
@@ -83,11 +96,13 @@ class ManageControllerTest {
         // Given : 추후 구현
 
         // When & Then
-        mvc.perform(get("/manage/c1/1/1"))
+        mvc.perform(get("/manage/clientId/campaignId/creativeId"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(view().name("manage/c1/1/1"))
-                .andExpect(model().attributeExists("manage/client/campaign/creative"));
+                .andExpect(view().name("manage/creative"))
+                .andExpect(model().attributeExists("clientId"))
+                .andExpect(model().attributeExists("campaignId"))
+                .andExpect(model().attributeExists("creativeId"));
     }
 
 }


### PR DESCRIPTION
광고 관리 (광고주 + 캠페인) 페이지를 구현한다
* [x] 뷰 엔드포인트 테스트
  * [x] 광고주 리스트
  * [x] 광고주 > 캠페인 리스트
  * [x] 광고주 > 캠페인 > 소재 리스트
* [x] 광고 관리 기능 임시 구현 (핸들러 메소드 생성만 하고 테스트 통과하게끔)
  * [x] 광고주 리스트 조회
  * [x] 광고주 > 캠페인 리스트 조회 및 세부 기능
  * [x] 광고주 > 캠페인 > 소재 리스트 조회 및 세부 기능
* [x] 페이지 구현

This closes #21 