### PR TITLE
에이전트 관리 기능 구현 + 뷰 적용

### DIFF
--- a/src/main/java/com/agencyplatformclonecoding/controller/AgentController.java
+++ b/src/main/java/com/agencyplatformclonecoding/controller/AgentController.java
@@ -45,7 +45,7 @@ public class AgentController {
     public String agent(@PathVariable String agentId, ModelMap map) {
     		AgentWithClientsResponse agent = AgentWithClientsResponse.from(agentService.getAgentWithClients(agentId));
 
-            map.addAttribute("agent", agent); // TODO : 실제 데이터 구현 시 여기에 넣어야 함
+            map.addAttribute("agent", agent);
             map.addAttribute("clients", agent.clientUserResponses());
     		map.addAttribute("totalCount", agentService.getAgentCount());
 

--- a/src/main/java/com/agencyplatformclonecoding/controller/AgentController.java
+++ b/src/main/java/com/agencyplatformclonecoding/controller/AgentController.java
@@ -1,14 +1,18 @@
 package com.agencyplatformclonecoding.controller;
 
+import com.agencyplatformclonecoding.domain.constrant.SearchType;
+import com.agencyplatformclonecoding.dto.response.AgentResponse;
+import com.agencyplatformclonecoding.dto.response.AgentWithClientsResponse;
 import com.agencyplatformclonecoding.service.AgentService;
 import com.agencyplatformclonecoding.service.PaginationService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -21,20 +25,43 @@ public class AgentController {
     private final PaginationService paginationService;
 
     @GetMapping
-    public String agents(ModelMap map) {
-        map.addAttribute("agents", List.of());
+    public String agents(
+                @RequestParam(required = false) SearchType searchType,
+                @RequestParam(required = false) String searchValue,
+                @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+                ModelMap map
+    	) {
+    		Page<AgentResponse> agents = agentService.searchAgents(searchType, searchValue, pageable)
+    				.map(AgentResponse::from);
+    		List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), agents.getTotalPages());
+            map.addAttribute("agents", agents);
+    		map.addAttribute("paginationBarNumbers", barNumbers);
+    		map.addAttribute("searchTypes", SearchType.values());
+
         return "agents/index";
     }
 
     @GetMapping("/{agentId}")
     public String agent(@PathVariable String agentId, ModelMap map) {
-        map.addAttribute("agent", "agent"); // TODO : 실제 데이터 구현 시 여기에 넣어야 함
-        map.addAttribute("clients", List.of());
+    		AgentWithClientsResponse agent = AgentWithClientsResponse.from(agentService.getAgentWithClients(agentId));
+
+            map.addAttribute("agent", agent); // TODO : 실제 데이터 구현 시 여기에 넣어야 함
+            map.addAttribute("clients", agent.clientUserResponses());
+    		map.addAttribute("totalCount", agentService.getAgentCount());
+
          return "agents/detail";
     }
     @GetMapping("/{agentId}/{clientId}")
     public String mappingClient(@PathVariable String agentId, String clientId) {
          return "forward:/manage/{clientId}";
      }
+
+    @PostMapping ("/{agentId}/delete")
+   	public String deleteAgent(@PathVariable String agentId) {
+   		agentService.deleteAgent(agentId);
+
+   		return "redirect:/agents";
+
+   	}
 
 }

--- a/src/main/java/com/agencyplatformclonecoding/domain/constrant/AgentGroupStatus.java
+++ b/src/main/java/com/agencyplatformclonecoding/domain/constrant/AgentGroupStatus.java
@@ -1,0 +1,15 @@
+package com.agencyplatformclonecoding.domain.constrant;
+
+import lombok.Getter;
+
+public enum AgentGroupStatus {
+    ACTIVATE("활성화"),
+    DELETED("삭제됨");
+
+    @Getter
+    private final String description;
+
+    AgentGroupStatus(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/agencyplatformclonecoding/domain/constrant/AgentStatus.java
+++ b/src/main/java/com/agencyplatformclonecoding/domain/constrant/AgentStatus.java
@@ -1,0 +1,15 @@
+package com.agencyplatformclonecoding.domain.constrant;
+
+import lombok.Getter;
+
+public enum AgentStatus {
+    ACTIVATE("활성화"),
+    DISABLED("탈퇴됨");
+
+    @Getter
+    private final String description;
+
+    AgentStatus(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/agencyplatformclonecoding/domain/constrant/ClientUserStatus.java
+++ b/src/main/java/com/agencyplatformclonecoding/domain/constrant/ClientUserStatus.java
@@ -1,0 +1,16 @@
+package com.agencyplatformclonecoding.domain.constrant;
+
+import lombok.Getter;
+
+public enum ClientUserStatus {
+    MAPPED("이관"),
+    UNMAPPED("OLS");
+
+    @Getter
+    private final String description;
+
+    ClientUserStatus(String description) {
+        this.description = description;
+    }
+}
+

--- a/src/main/java/com/agencyplatformclonecoding/domain/constrant/SearchType.java
+++ b/src/main/java/com/agencyplatformclonecoding/domain/constrant/SearchType.java
@@ -1,0 +1,15 @@
+package com.agencyplatformclonecoding.domain.constrant;
+
+import lombok.Getter;
+
+public enum SearchType {
+    ID("유저 ID"),
+    NICKNAME("유저 이름");
+
+    @Getter private final String description;
+
+    SearchType(String description) {
+        this.description = description;
+    }
+}
+

--- a/src/main/java/com/agencyplatformclonecoding/dto/AgencyDto.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/AgencyDto.java
@@ -1,0 +1,29 @@
+package com.agencyplatformclonecoding.dto;
+
+import com.agencyplatformclonecoding.domain.Agency;
+
+public record AgencyDto(
+        String agencyId,
+        String agencyName
+) {
+
+    public static AgencyDto of(String agencyId, String agencyName) {
+        return new AgencyDto(agencyId, agencyName);
+    }
+
+    // Entity -> dto로 변환
+    public static AgencyDto from(Agency entity) {
+        return new AgencyDto(
+				entity.getAgencyId(),
+                entity.getAgencyName()
+        );
+    }
+
+    // dto -> Entity로 변환
+    public Agency toEntity() {
+        return Agency.of(
+                agencyId,
+				agencyName
+        );
+    }
+}

--- a/src/main/java/com/agencyplatformclonecoding/dto/AgentDto.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/AgentDto.java
@@ -1,4 +1,57 @@
 package com.agencyplatformclonecoding.dto;
 
-public class AgentDto {
+import com.agencyplatformclonecoding.domain.Agency;
+import com.agencyplatformclonecoding.domain.Agent;
+import com.agencyplatformclonecoding.domain.AgentGroup;
+
+import java.time.LocalDateTime;
+
+public record AgentDto(
+
+		AgencyDto agencyDto,
+        AgentGroupDto agentGroupDto,
+        String userId,
+        String userPassword,
+        String nickname,
+        String email,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+
+    public static AgentDto of(AgencyDto agencyDto, AgentGroupDto agentGroupDto, String userPassword, String nickname, String email) {
+        return new AgentDto(agencyDto, agentGroupDto, null, userPassword, nickname, email, null, null, null, null);
+    }
+    public static AgentDto of(AgencyDto agencyDto, AgentGroupDto agentGroupDto, String userId, String userPassword, String nickname, String email, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new AgentDto(agencyDto, agentGroupDto, userId, userPassword, nickname, email, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    // Entity -> dto로 변환
+    public static AgentDto from(Agent entity) {
+        return new AgentDto(
+                AgencyDto.from(entity.getAgency()),
+				AgentGroupDto.from(entity.getAgentGroup()),
+				entity.getUserId(),
+                entity.getUserPassword(),
+                entity.getNickname(),
+                entity.getEmail(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+    // dto -> Entity로 변환
+    public Agent toEntity(Agency agency, AgentGroup agentGroup) {
+        return Agent.of(
+                agency,
+				agentGroup,
+                userId,
+				userPassword,
+                nickname,
+                email
+        );
+    }
 }

--- a/src/main/java/com/agencyplatformclonecoding/dto/AgentGroupDto.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/AgentGroupDto.java
@@ -1,0 +1,45 @@
+package com.agencyplatformclonecoding.dto;
+
+import com.agencyplatformclonecoding.domain.Agency;
+import com.agencyplatformclonecoding.domain.AgentGroup;
+
+import java.time.LocalDateTime;
+
+public record AgentGroupDto(
+		AgencyDto agencyDto,
+        String id,
+        String name,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+
+    public static AgentGroupDto of(AgencyDto agencyDto, String name) {
+        return new AgentGroupDto(agencyDto, null, name, null, null, null, null);
+    }
+    public static AgentGroupDto of(AgencyDto agencyDto, String id, String name, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new AgentGroupDto(agencyDto, id, name, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    // Entity -> dto로 변환
+    public static AgentGroupDto from(AgentGroup entity) {
+        return new AgentGroupDto(
+                AgencyDto.from(entity.getAgency()),
+				entity.getId(),
+                entity.getName(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+    // dto -> Entity로 변환
+    public AgentGroup toEntity(Agency agency) {
+        return AgentGroup.of(
+                agency,
+				name
+        );
+    }
+}

--- a/src/main/java/com/agencyplatformclonecoding/dto/AgentGroupWithAgentsDto.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/AgentGroupWithAgentsDto.java
@@ -1,0 +1,41 @@
+package com.agencyplatformclonecoding.dto;
+
+import com.agencyplatformclonecoding.domain.Agency;
+import com.agencyplatformclonecoding.domain.AgentGroup;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record AgentGroupWithAgentsDto(
+        AgencyDto agencyDto,
+        Set<AgentDto> agentDtos,
+        String id,
+        String name,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+
+    public static AgentGroupWithAgentsDto of(AgencyDto agencyDto, Set<AgentDto> agentDtos, String id, String name, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new AgentGroupWithAgentsDto(agencyDto, agentDtos, id, name, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    // Entity -> dto로 변환
+    public static AgentGroupWithAgentsDto from(AgentGroup entity) {
+        return new AgentGroupWithAgentsDto(
+                AgencyDto.from(entity.getAgency()),
+				entity.getAgents().stream()
+                        .map(AgentDto::from)
+						.collect(Collectors.toCollection(LinkedHashSet::new)),
+				entity.getId(),
+                entity.getName(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+}

--- a/src/main/java/com/agencyplatformclonecoding/dto/AgentWithClientsDto.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/AgentWithClientsDto.java
@@ -1,0 +1,47 @@
+package com.agencyplatformclonecoding.dto;
+
+import com.agencyplatformclonecoding.domain.Agent;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record AgentWithClientsDto(
+        AgencyDto agencyDto,
+        AgentGroupDto agentGroupDto,
+        Set<ClientUserDto> clientUserDtos,
+        String userId,
+        String userPassword,
+        String nickname,
+        String email,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+
+    public static AgentWithClientsDto of(AgencyDto agencyDto, AgentGroupDto agentGroupDto, Set<ClientUserDto> clientUserDtos, String userId, String password, String nickname, String email, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new AgentWithClientsDto(agencyDto, agentGroupDto, clientUserDtos, userId, password, nickname, email, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    // Entity -> dto로 변환
+    public static AgentWithClientsDto from(Agent entity) {
+        return new AgentWithClientsDto(
+                AgencyDto.from(entity.getAgency()),
+				AgentGroupDto.from(entity.getAgentGroup()),
+				entity.getClientUsers().stream()
+						.map(ClientUserDto::from)
+						.collect(Collectors.toCollection(LinkedHashSet::new)),
+				entity.getUserId(),
+                entity.getUserPassword(),
+                entity.getNickname(),
+                entity.getEmail(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+}

--- a/src/main/java/com/agencyplatformclonecoding/dto/ClientUserDto.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/ClientUserDto.java
@@ -1,0 +1,58 @@
+package com.agencyplatformclonecoding.dto;
+
+import com.agencyplatformclonecoding.domain.Agency;
+import com.agencyplatformclonecoding.domain.Agent;
+import com.agencyplatformclonecoding.domain.ClientUser;
+
+import java.time.LocalDateTime;
+
+import static com.agencyplatformclonecoding.domain.QAgency.agency;
+
+public record ClientUserDto(
+        AgencyDto agencyDto,
+        AgentDto agentDto,
+        String userId,
+        String userPassword,
+        String nickname,
+        String email,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+
+    public static ClientUserDto of(AgencyDto agencyDto, AgentDto agentDto, String password, String nickname, String email) {
+        return new ClientUserDto(agencyDto, agentDto, null, password, nickname, email, null, null, null, null);
+    }
+    public static ClientUserDto of(AgencyDto agencyDto, AgentDto agentDto, String userId, String password, String nickname, String email, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new ClientUserDto(agencyDto, agentDto, userId, password, nickname, email, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    // Entity -> dto로 변환
+    public static ClientUserDto from(ClientUser entity) {
+        return new ClientUserDto(
+                AgencyDto.from(entity.getAgency()),
+				AgentDto.from(entity.getAgent()),
+				entity.getUserId(),
+                entity.getUserPassword(),
+                entity.getNickname(),
+                entity.getEmail(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+    // dto -> Entity로 변환
+    public ClientUser toEntity(Agency agency, Agent agent) {
+        return ClientUser.of(
+                agency,
+                agent,
+                userId,
+				userPassword,
+                nickname,
+                email
+        );
+    }
+}

--- a/src/main/java/com/agencyplatformclonecoding/dto/response/AgentResponse.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/response/AgentResponse.java
@@ -9,23 +9,25 @@ public record AgentResponse (
         String userId,
         LocalDateTime createdAt,
         String nickname,
-        String email
+        String email,
+        String agentGroupName
 ) implements Serializable {
 
-    public static AgentResponse of(String userId, LocalDateTime createdAt, String nickname, String email) {
-        return new AgentResponse(userId, createdAt, nickname, email);
+    public static AgentResponse of(String userId, LocalDateTime createdAt, String nickname, String email, String agentGroupName) {
+        return new AgentResponse(userId, createdAt, nickname, email, agentGroupName);
     }
 
     public static AgentResponse from(AgentDto dto) {
-        String nickname = dto.nickname();
-        if (nickname == null || nickname.isBlank()) {
-            nickname = dto.userId();
+        String agentGroupName = dto.agentGroupDto().name();
+        if (agentGroupName == null || agentGroupName.isBlank()) {
+            agentGroupName = dto.agentGroupDto().id();
         }
         return new AgentResponse(
                 dto.userId(),
                 dto.createdAt(),
-                nickname,
-                dto.email()
+                dto.nickname(),
+                dto.email(),
+                agentGroupName
         );
     }
 }

--- a/src/main/java/com/agencyplatformclonecoding/dto/response/AgentWithClientsResponse.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/response/AgentWithClientsResponse.java
@@ -12,26 +12,28 @@ public record AgentWithClientsResponse(
         String userId,
         LocalDateTime createdAt,
         String nickname,
-        Set<ClientUserResponse> clientUserResponses
+        Set<ClientUserResponse> clientUserResponses,
+        String agentGroupName
 ) implements Serializable {
 
-    public static AgentWithClientsResponse of (String userId, LocalDateTime createdAt, String nickname, Set<ClientUserResponse> clientUserResponses) {
-        return new AgentWithClientsResponse(userId, createdAt, nickname, clientUserResponses);
+    public static AgentWithClientsResponse of (String userId, LocalDateTime createdAt, String nickname, Set<ClientUserResponse> clientUserResponses, String agentGroupName) {
+        return new AgentWithClientsResponse(userId, createdAt, nickname, clientUserResponses, agentGroupName);
     }
 
     public static AgentWithClientsResponse from(AgentWithClientsDto dto) {
-        String nickname = dto.nickname();
-        if (nickname == null || nickname.isBlank()) {
-            nickname = dto.userId();
+        String agentGroupName = dto.agentGroupDto().name();
+        if (agentGroupName == null || agentGroupName.isBlank()) {
+            agentGroupName = dto.agentGroupDto().id();
         }
 
         return new AgentWithClientsResponse(
                 dto.userId(),
                 dto.createdAt(),
-                nickname,
+                dto.nickname(),
                 dto.clientUserDtos().stream()
                         .map(ClientUserResponse::from)
-                        .collect(Collectors.toCollection(LinkedHashSet::new))
+                        .collect(Collectors.toCollection(LinkedHashSet::new)),
+                agentGroupName
         );
     }
 

--- a/src/main/java/com/agencyplatformclonecoding/dto/response/AgentWithClientsResponse.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/response/AgentWithClientsResponse.java
@@ -1,0 +1,38 @@
+package com.agencyplatformclonecoding.dto.response;
+
+import com.agencyplatformclonecoding.dto.AgentWithClientsDto;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record AgentWithClientsResponse(
+        String userId,
+        LocalDateTime createdAt,
+        String nickname,
+        Set<ClientUserResponse> clientUserResponses
+) implements Serializable {
+
+    public static AgentWithClientsResponse of (String userId, LocalDateTime createdAt, String nickname, Set<ClientUserResponse> clientUserResponses) {
+        return new AgentWithClientsResponse(userId, createdAt, nickname, clientUserResponses);
+    }
+
+    public static AgentWithClientsResponse from(AgentWithClientsDto dto) {
+        String nickname = dto.nickname();
+        if (nickname == null || nickname.isBlank()) {
+            nickname = dto.userId();
+        }
+
+        return new AgentWithClientsResponse(
+                dto.userId(),
+                dto.createdAt(),
+                nickname,
+                dto.clientUserDtos().stream()
+                        .map(ClientUserResponse::from)
+                        .collect(Collectors.toCollection(LinkedHashSet::new))
+        );
+    }
+
+}

--- a/src/main/java/com/agencyplatformclonecoding/dto/response/ClientUserResponse.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/response/ClientUserResponse.java
@@ -6,27 +6,31 @@ import java.io.Serializable;
 import java.time.LocalDateTime;
 
 public record ClientUserResponse(
-        String clientId,
+        String userId,
         LocalDateTime createdAt,
         String nickname,
-        String email
+        String email,
+        String agentId,
+        String agentName
 ) implements Serializable {
 
-    public static ClientUserResponse of (String clientId, LocalDateTime createdAt, String nickname, String email) {
-        return new ClientUserResponse(clientId, createdAt, nickname, email);
+    public static ClientUserResponse of (String userId, LocalDateTime createdAt, String nickname, String email, String agentId, String agentName) {
+        return new ClientUserResponse(userId, createdAt, nickname, email, agentId, agentName);
     }
 
     public static ClientUserResponse from (ClientUserDto dto) {
-        String nickname = dto.nickname();
-        if (nickname == null || nickname.isBlank()) {
-            nickname = dto.userId();
+        String agentName = dto.agentDto().nickname();
+        if (agentName == null || agentName.isBlank()) {
+            agentName = dto.agentDto().userId();
         }
 
         return new ClientUserResponse(
                 dto.userId(),
                 dto.createdAt(),
-                nickname,
-                dto.email()
+                dto.nickname(),
+                dto.email(),
+                dto.agentDto().userId(),
+                agentName
         );
     }
 }

--- a/src/main/java/com/agencyplatformclonecoding/dto/response/ClientUserResponse.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/response/ClientUserResponse.java
@@ -1,27 +1,28 @@
 package com.agencyplatformclonecoding.dto.response;
 
-import com.agencyplatformclonecoding.dto.AgentDto;
+import com.agencyplatformclonecoding.dto.ClientUserDto;
 
 import java.io.Serializable;
 import java.time.LocalDateTime;
 
-public record AgentResponse (
-        String userId,
+public record ClientUserResponse(
+        String clientId,
         LocalDateTime createdAt,
         String nickname,
         String email
 ) implements Serializable {
 
-    public static AgentResponse of(String userId, LocalDateTime createdAt, String nickname, String email) {
-        return new AgentResponse(userId, createdAt, nickname, email);
+    public static ClientUserResponse of (String clientId, LocalDateTime createdAt, String nickname, String email) {
+        return new ClientUserResponse(clientId, createdAt, nickname, email);
     }
 
-    public static AgentResponse from(AgentDto dto) {
+    public static ClientUserResponse from (ClientUserDto dto) {
         String nickname = dto.nickname();
         if (nickname == null || nickname.isBlank()) {
             nickname = dto.userId();
         }
-        return new AgentResponse(
+
+        return new ClientUserResponse(
                 dto.userId(),
                 dto.createdAt(),
                 nickname,

--- a/src/main/java/com/agencyplatformclonecoding/repository/AgencyRepository.java
+++ b/src/main/java/com/agencyplatformclonecoding/repository/AgencyRepository.java
@@ -1,7 +1,13 @@
 package com.agencyplatformclonecoding.repository;
 
 import com.agencyplatformclonecoding.domain.Agency;
+import com.agencyplatformclonecoding.domain.AgentGroup;
+import com.agencyplatformclonecoding.domain.QAgency;
+import com.agencyplatformclonecoding.domain.QAgentGroup;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 public interface AgencyRepository extends JpaRepository<Agency, String> {
 }

--- a/src/main/java/com/agencyplatformclonecoding/repository/AgentGroupRepository.java
+++ b/src/main/java/com/agencyplatformclonecoding/repository/AgentGroupRepository.java
@@ -1,18 +1,31 @@
 package com.agencyplatformclonecoding.repository;
 
+import com.agencyplatformclonecoding.domain.Agent;
 import com.agencyplatformclonecoding.domain.AgentGroup;
+import com.agencyplatformclonecoding.domain.ClientUser;
 import com.agencyplatformclonecoding.domain.QAgentGroup;
 import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.StringExpression;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
 import org.springframework.data.querydsl.binding.QuerydslBindings;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+import java.util.List;
+
+@RepositoryRestResource
 public interface AgentGroupRepository extends
         JpaRepository<AgentGroup, String>,
         QuerydslPredicateExecutor<AgentGroup>,
         QuerydslBinderCustomizer<QAgentGroup> {
+
+    Page<AgentGroup> findByIdContaining(String id, Pageable pageable);
+    Page<AgentGroup> findByNameContaining(String nickname, Pageable pageable);
+
+    void deleteAgentGroupById(String agentGroupId);
 
     @Override
     default void customize(QuerydslBindings bindings, QAgentGroup root) {

--- a/src/main/java/com/agencyplatformclonecoding/repository/AgentRepository.java
+++ b/src/main/java/com/agencyplatformclonecoding/repository/AgentRepository.java
@@ -1,7 +1,6 @@
 package com.agencyplatformclonecoding.repository;
 
 import com.agencyplatformclonecoding.domain.Agent;
-import com.agencyplatformclonecoding.domain.ClientUser;
 import com.agencyplatformclonecoding.domain.QAgent;
 import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.StringExpression;
@@ -26,7 +25,7 @@ public interface AgentRepository extends
 
     List<Agent> findByAgentGroup_Id(String agentGroupId);
 
-    void deleteAgentByUserId(String agentId);
+    void deleteByUserId(String agentId);
 
     @Override
     default void customize(QuerydslBindings bindings, QAgent root) {

--- a/src/main/java/com/agencyplatformclonecoding/repository/AgentRepository.java
+++ b/src/main/java/com/agencyplatformclonecoding/repository/AgentRepository.java
@@ -1,18 +1,32 @@
 package com.agencyplatformclonecoding.repository;
 
 import com.agencyplatformclonecoding.domain.Agent;
+import com.agencyplatformclonecoding.domain.ClientUser;
 import com.agencyplatformclonecoding.domain.QAgent;
 import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.StringExpression;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
 import org.springframework.data.querydsl.binding.QuerydslBindings;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+import java.util.List;
+
+@RepositoryRestResource
 public interface AgentRepository extends
         JpaRepository<Agent, String>,
         QuerydslPredicateExecutor<Agent>,
         QuerydslBinderCustomizer<QAgent> {
+
+    Page<Agent> findByUserIdContaining(String userId, Pageable pageable);
+    Page<Agent> findByNicknameContaining(String nickname, Pageable pageable);
+
+    List<Agent> findByAgentGroup_Id(String agentGroupId);
+
+    void deleteAgentByUserId(String agentId);
 
     @Override
     default void customize(QuerydslBindings bindings, QAgent root) {

--- a/src/main/java/com/agencyplatformclonecoding/repository/ClientUserRepository.java
+++ b/src/main/java/com/agencyplatformclonecoding/repository/ClientUserRepository.java
@@ -4,15 +4,24 @@ import com.agencyplatformclonecoding.domain.ClientUser;
 import com.agencyplatformclonecoding.domain.QClientUser;
 import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.StringExpression;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
 import org.springframework.data.querydsl.binding.QuerydslBindings;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+import java.util.List;
+
+@RepositoryRestResource
 public interface ClientUserRepository extends
         JpaRepository<ClientUser, String>,
         QuerydslPredicateExecutor<ClientUser>,
         QuerydslBinderCustomizer<QClientUser> {
+
+    Page<ClientUser> findByAgent_UserIdContaining(String userId, Pageable pageable);
+    List<ClientUser> findByAgent_UserId(String userId);
 
     @Override
     default void customize(QuerydslBindings bindings, QClientUser root) {

--- a/src/main/java/com/agencyplatformclonecoding/service/AgentGroupService.java
+++ b/src/main/java/com/agencyplatformclonecoding/service/AgentGroupService.java
@@ -1,12 +1,25 @@
 package com.agencyplatformclonecoding.service;
 
+import com.agencyplatformclonecoding.domain.Agency;
+import com.agencyplatformclonecoding.domain.Agent;
+import com.agencyplatformclonecoding.domain.AgentGroup;
+import com.agencyplatformclonecoding.domain.constrant.SearchType;
+import com.agencyplatformclonecoding.dto.AgentDto;
+import com.agencyplatformclonecoding.dto.AgentGroupDto;
+import com.agencyplatformclonecoding.dto.AgentGroupWithAgentsDto;
+import com.agencyplatformclonecoding.repository.AgencyRepository;
 import com.agencyplatformclonecoding.repository.AgentGroupRepository;
 import com.agencyplatformclonecoding.repository.AgentRepository;
 import com.agencyplatformclonecoding.repository.ClientUserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -14,7 +27,90 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class AgentGroupService {
 
-    private final AgentRepository agentRepository;
-    private final AgentGroupRepository agentGroupRepository;
+	private final AgencyRepository agencyRepository;
+	private final AgentGroupRepository agentGroupRepository;
+	private final AgentRepository agentRepository;
 
+	@Transactional(readOnly = true)
+	public AgentGroupDto getAgentGroup(String agentGroupId) {
+		return agentGroupRepository.findById(agentGroupId)
+				.map(AgentGroupDto::from)
+				.orElseThrow(() -> new EntityNotFoundException("에이전트 그룹이 존재하지 않습니다 - agentGroupId : " + agentGroupId));
+	}
+
+	@Transactional(readOnly = true)
+	public AgentGroupWithAgentsDto getAgentGroupWithAgents(String agentGroupId) {
+		return agentGroupRepository.findById(agentGroupId)
+				.map(AgentGroupWithAgentsDto::from)
+				.orElseThrow(() -> new EntityNotFoundException("에이전트 그룹이 존재하지 않습니다 - agentGroupId : " + agentGroupId));
+	}
+
+	@Transactional(readOnly = true)
+	public Page<AgentGroupDto> searchAgentGroups(SearchType searchType, String searchKeyword, Pageable pageable) {
+		if (searchKeyword == null || searchKeyword.isBlank()) {
+			return agentGroupRepository.findAll(pageable).map(AgentGroupDto::from);
+		}
+
+		return switch(searchType) {
+			case ID -> agentGroupRepository.findByIdContaining(searchKeyword, pageable).map(AgentGroupDto::from);
+			case NICKNAME -> agentGroupRepository.findByNameContaining(searchKeyword, pageable).map(AgentGroupDto::from);
+		};
+	}
+
+	public void saveAgentGroup(AgentGroupDto dto) {
+		Agency agency = agencyRepository.getReferenceById(dto.agencyDto().agencyId());
+		agentGroupRepository.save(dto.toEntity(agency));
+	}
+
+	public void saveAgentInAgentGroup(String agentGroupId, AgentDto dto) {
+		Agency agency = agencyRepository.getReferenceById(dto.agencyDto().agencyId());
+		AgentGroup agentGroup = agentGroupRepository.getReferenceById(dto.agentGroupDto().id());
+		agentRepository.save(dto.toEntity(agency, agentGroup));
+	}
+
+	public void updateAgentGroup(String agentGroupId, AgentGroupDto dto) {
+
+		try {
+			AgentGroup agentGroup = agentGroupRepository.getReferenceById(agentGroupId);
+			Agency agency = agencyRepository.getReferenceById(dto.agencyDto().agencyId());
+
+			if (agentGroup.getAgency().equals(agency))
+				if (dto.name() != null) {
+					agentGroup.setName(dto.name());
+				}
+		} catch (EntityNotFoundException e) {
+			log.warn("에이전트 그룹을 수정하는데 필요한 정보를 찾을 수 없습니다. - dto : {}", e.getLocalizedMessage());
+		}
+	}
+
+	public void deleteAgentGroup(String agentGroupId) {
+
+		try {
+			AgentGroup agentGroup = agentGroupRepository.getReferenceById(agentGroupId);
+			List<Agent> agents = agentRepository.findByAgentGroup_Id(agentGroupId);
+
+			if (agents.size() == 0) {
+				agentGroupRepository.deleteAgentGroupById(agentGroupId);
+			} else {
+				throw new IllegalArgumentException();
+			}
+		} catch (EntityNotFoundException e) {
+			log.warn("에이전트 그룹을 삭제하는데 필요한 정보를 찾을 수 없습니다. - agentGroupId : {}", e.getLocalizedMessage());
+		} catch (IllegalArgumentException e) {
+			log.warn("소속된 에이전트가 남아 있어 에이전트 그룹을 삭제할 수 없습니다. - agentGroupId : {}", e.getLocalizedMessage());
+		}
+	}
+
+	public long getAgentGroupCount() {
+		return agentGroupRepository.count();
+	}
+
+	public int getAgentCount(String agentGroupId) {
+		List<Agent> agents = agentRepository.findByAgentGroup_Id(agentGroupId);
+		if (agents != null) {
+			return agents.size();
+		} else {
+			return 0;
+		}
+	}
 }

--- a/src/main/java/com/agencyplatformclonecoding/service/AgentService.java
+++ b/src/main/java/com/agencyplatformclonecoding/service/AgentService.java
@@ -1,12 +1,26 @@
 package com.agencyplatformclonecoding.service;
 
+import com.agencyplatformclonecoding.domain.Agency;
+import com.agencyplatformclonecoding.domain.Agent;
+import com.agencyplatformclonecoding.domain.AgentGroup;
+import com.agencyplatformclonecoding.domain.ClientUser;
+import com.agencyplatformclonecoding.domain.constrant.SearchType;
+import com.agencyplatformclonecoding.dto.AgentDto;
+import com.agencyplatformclonecoding.dto.AgentWithClientsDto;
+import com.agencyplatformclonecoding.repository.AgencyRepository;
 import com.agencyplatformclonecoding.repository.AgentGroupRepository;
 import com.agencyplatformclonecoding.repository.AgentRepository;
 import com.agencyplatformclonecoding.repository.ClientUserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -16,5 +30,50 @@ public class AgentService {
 
     private final AgentRepository agentRepository;
     private final AgentGroupRepository agentGroupRepository;
+    private final AgencyRepository agencyRepository;
     private final ClientUserRepository clientUserRepository;
+
+    @Transactional(readOnly = true)
+    public AgentDto getAgent(String agentId) {
+        return agentRepository.findById(agentId)
+                .map(AgentDto::from)
+                .orElseThrow(() -> new EntityNotFoundException("에이전트가 존재하지 않습니다 - agentId : " + agentId));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<AgentDto> searchAgents(SearchType searchType, String searchKeyword, Pageable pageable) {
+        if (searchKeyword == null || searchKeyword.isBlank()) {
+            return agentRepository.findAll(pageable).map(AgentDto::from);
+        }
+
+        return switch(searchType) {
+            case ID -> agentRepository.findByUserIdContaining(searchKeyword, pageable).map(AgentDto::from);
+            case NICKNAME -> agentRepository.findByNicknameContaining(searchKeyword, pageable).map(AgentDto::from);
+        };
+    }
+
+    @Transactional(readOnly = true)
+    public AgentWithClientsDto getAgentWithClients(String agentId) {
+        return agentRepository.findById(agentId)
+                .map(AgentWithClientsDto::from)
+                .orElseThrow(() -> new EntityNotFoundException("에이전트가 존재하지 않습니다 - agentId : " + agentId));
+    }
+
+    public void deleteAgent(String agentId) {
+        try {
+            List<ClientUser> clientUsers = clientUserRepository.findByAgent_UserId(agentId);
+
+            if (clientUsers.size() == 0) {
+                agentRepository.deleteAgentByUserId(agentId);
+            } else {
+                throw new IllegalArgumentException();
+            }
+        } catch (EntityNotFoundException e) {
+            log.warn("에이전트를 삭제하지 못하였습니다. 에이전트가 존재하지 않습니다.", e.getLocalizedMessage());
+        }
+    }
+
+    public long getAgentCount() {
+        return agentRepository.count();
+    }
 }

--- a/src/main/java/com/agencyplatformclonecoding/service/AgentService.java
+++ b/src/main/java/com/agencyplatformclonecoding/service/AgentService.java
@@ -1,8 +1,5 @@
 package com.agencyplatformclonecoding.service;
 
-import com.agencyplatformclonecoding.domain.Agency;
-import com.agencyplatformclonecoding.domain.Agent;
-import com.agencyplatformclonecoding.domain.AgentGroup;
 import com.agencyplatformclonecoding.domain.ClientUser;
 import com.agencyplatformclonecoding.domain.constrant.SearchType;
 import com.agencyplatformclonecoding.dto.AgentDto;
@@ -20,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityNotFoundException;
 import java.util.List;
-import java.util.Set;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -63,8 +59,8 @@ public class AgentService {
         try {
             List<ClientUser> clientUsers = clientUserRepository.findByAgent_UserId(agentId);
 
-            if (clientUsers.size() == 0) {
-                agentRepository.deleteAgentByUserId(agentId);
+            if (clientUsers.isEmpty()) {
+                agentRepository.deleteByUserId(agentId);
             } else {
                 throw new IllegalArgumentException();
             }

--- a/src/main/java/com/agencyplatformclonecoding/service/PaginationService.java
+++ b/src/main/java/com/agencyplatformclonecoding/service/PaginationService.java
@@ -2,6 +2,24 @@ package com.agencyplatformclonecoding.service;
 
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.IntStream;
+
 @Service
 public class PaginationService {
+    private static final int BAR_LENGTH = 5;
+
+    public List<Integer> getPaginationBarNumbers(int currentPageNumber, int totalPages) {
+        int startNumber = Math.max(currentPageNumber - (BAR_LENGTH / 2), 0);
+        // 기본 골자는 현재 페이지 - (길이 / 2) 겠지만 0보다 작으면 0 반환
+        int endNumber = Math.min(startNumber + BAR_LENGTH, totalPages);
+        // startNumber + 길이가 totalPages를 넘지 않게
+
+        return IntStream.range(startNumber, endNumber).boxed().toList();
+    }
+
+    public int currentBarLength() {
+        return BAR_LENGTH;
+    }
+
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -33,7 +33,8 @@ insert into agent (agent_id, agent_group_id, agency_id, created_at, created_by, 
 ('agent17', 'mkthq', 'TestAgency', '2022-02-09 21:12:38', 'Archaimbaud', '2021-12-01 10:03:21', 'Archaimbaud', 'adimmneg@shareasale.com', 'Archaimbaud', 'B0s4vN8p7G'),
 ('agent18', 'mkt5', 'TestAgency', '2022-03-14 04:58:46', 'Sydney', '2022-04-09 22:58:38', 'Sydney', 'ssmithendh@skype.com', 'Sydney', 'Uw6uv2vh'),
 ('agent19', 'mkthq', 'TestAgency', '2021-11-02 20:34:27', 'Donica', '2022-06-18 09:16:21', 'Donica', 'dlaughreyi@constantcontact.com', 'Donica', 'iW0mlxHrJ4bo'),
-('agent20', 'mkthq', 'TestAgency', '2022-04-27 22:31:37', 'Heida', '2022-04-28 00:50:10', 'Heida', 'hgaleyj@meetup.com', 'Heida', 'BfMqWo0kH');
+('agent20', 'mkthq', 'TestAgency', '2022-04-27 22:31:37', 'Heida', '2022-04-28 00:50:10', 'Heida', 'hgaleyj@meetup.com', 'Heida', 'BfMqWo0kH'),
+('testagent', 'mkthq', 'TestAgency', '2022-04-27 22:31:37', '김쾅쾅', '2022-04-28 00:50:10', '김쾅쾅', 'hgaleyj@meetup.com', 'Heida', 'BfMqWo0kH');
 
 
 -- 광고주 관련 (100명)

--- a/src/main/resources/templates/agentgroups/index.html
+++ b/src/main/resources/templates/agentgroups/index.html
@@ -108,7 +108,6 @@
           <th class="nickname col-2"><a>그룹명</a></th>
           <th class="created-at col"><a>그룹 생성일</a></th>
           <th class="profile col-2"><a>소속 에이전트 확인</a></th>
-          <th class="headcount col-2"><a>소속 인원 수</a></th>
           <th class="button"><a></a></th>
         </tr>
         </thead>
@@ -118,7 +117,6 @@
           <td class="nickname">마케팅 1팀</td>
           <td class="clients"><time>2022-08-18</time></td>
           <td class="profile">소속 에이전트 확인</td>
-          <td class="headcount">3</td>
           <td class="button"><a class="btn btn-danger me-md-2" role="button" id="agent-delete">삭제</a></td>
         </tr>
         <tr>
@@ -126,7 +124,6 @@
           <td>마케팅 2팀</td>
           <td>2022-08-19</td>
           <td class="profile">소속 에이전트 확인</td>
-          <td class="headcount">2</td>
           <td class="button"><a class="btn btn-danger me-md-2" role="button" id="agent-delete">삭제</a></td>
         </tr>
         <tr>
@@ -134,7 +131,6 @@
           <td>마케팅 3팀</td>
           <td>2022-08-20</td>
           <td class="profile">소속 에이전트 확인</td>
-          <td class="headcount">5</td>
           <td class="button"><a class="btn btn-danger me-md-2" role="button" id="agent-delete">삭제</a></td>
         </tr>
         <tr>
@@ -142,7 +138,6 @@
           <td>마케팅 5팀</td>
           <td>2022-08-20</td>
           <td class="profile">소속 에이전트 확인</td>
-          <td class="headcount">2</td>
           <td class="button"><a class="btn btn-danger me-md-2" role="button" id="agent-delete">삭제</a></td>
         </tr>
         <tr>
@@ -150,7 +145,6 @@
           <td>마케팅 본부</td>
           <td>2022-08-20</td>
           <td class="profile">소속 에이전트 확인</td>
-          <td class="headcount">8</td>
           <td class="button"><a class="btn btn-danger me-md-2" role="button" id="agent-delete">삭제</a></td>
         </tr>
       </tbody>

--- a/src/main/resources/templates/agents/detail.html
+++ b/src/main/resources/templates/agents/detail.html
@@ -1,10 +1,111 @@
 <!DOCTYPE html>
-<html lang="ko">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="">
+  <meta name="author" content="mrcocoball">
   <title>에이전트 상세 페이지</title>
+
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+  <link href="/css/search-bar.css" rel="stylesheet">
+  <link href="/css/articles/table-header.css" rel="stylesheet">
 </head>
+
 <body>
 
+  <header id="header">
+    헤더 삽입부
+    <hr>
+  </header>
+
+  <main class="d-flex flex-nowrap">
+    <div class="d-flex flex-column flex-shrink-0 p-3 text-bg-dark" style="width: 280px;, height: 100%;">
+      <a href="/" class="d-flex align-items-center mb-3 mb-md-0 me-md-auto text-white text-decoration-none">
+        <svg class="bi pe-none me-2" width="40" height="32"><use xlink:href="#bootstrap"/></svg>
+        <span class="fs-4"></span>
+      </a>
+      <ul class="nav nav-pills flex-column mb-auto">
+        <li class="nav-item">
+          <a href="#" class="nav-link active" aria-current="page">
+            <svg class="bi pe-none me-2" width="16" height="16"><use xlink:href="#home"/></svg>
+            에이전트 관리
+          </a>
+        </li>
+        <li>
+          <a href="#" class="nav-link text-white">
+            <svg class="bi pe-none me-2" width="16" height="16"><use xlink:href="#speedometer2"/></svg>
+            에이전트 그룹 관리
+          </a>
+        </li>
+        <li>
+          <a href="#" class="nav-link text-white">
+            <svg class="bi pe-none me-2" width="16" height="16"><use xlink:href="#table"/></svg>
+            광고주 관리
+          </a>
+        </li>
+        <li>
+          <a href="#" class="nav-link text-white">
+            <svg class="bi pe-none me-2" width="16" height="16"><use xlink:href="#grid"/></svg>
+            광고 관리
+          </a>
+        </li>
+        <li>
+          <a href="#" class="nav-link text-white">
+            <svg class="bi pe-none me-2" width="16" height="16"><use xlink:href="#people-circle"/></svg>
+            대시보드
+          </a>
+        </li>
+    </div>
+
+   <div class="container">
+   <h1> 에이전트 정보 </h1>
+    <div class="row">
+	  <table class="table" id="agent-info">
+		<thead>
+        <tr>
+          <th class="user-id col-2"><a>ID</a></th>
+          <th class="nickname col-2"><a>이름</a></th>
+          <th class="agent-group col-2"><a>그룹</a></th>
+          <th class="created-at col"><a>계정 생성일</a></th>
+        </tr>
+        </thead>
+		<tbody>
+		<tr>
+          <td class="user-id">cocoballagent</td>
+          <td class="nickname">김코코볼</td>
+          <td class="agent-group">마케팅 1팀</td>
+          <td class="created-at">2022-08-18</td>
+        </tr>
+		</tbody>
+    </table>
+    </div>
+
+    <div class="row">
+      <table class="table" id="client-table">
+        <thead>
+        <tr>
+          <th class="client-id col-2"><a>ID</a></th>
+          <th class="nickname col-2"><a>이름</a></th>
+          <th class="client-manage"></th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <td class="client-id"><a>client1</a></td>
+          <td class="nickname">코코볼자동차</td>
+          <th class="button"><a class="btn btn-primary" role="button" id="client-manage">광고주 관리</a></th>
+        </tr>
+        <tr>
+          <td>client2</td>
+          <td>코코볼전자</td>
+          <th class="button"><a class="btn btn-primary" role="button" id="client-manage">광고주 관리</a></th>
+        </tr>
+      </tbody>
+    </table>
+    </div>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-A3rJD856KowSb7dwlZdYEkO39Gagi7vIsF0jrRAoQmDKKtQBHUuLZ9AsSv4jD4Xa" crossorigin="anonymous"></script>
+
 </body>
-</html>

--- a/src/main/resources/templates/agents/detail.th.xml
+++ b/src/main/resources/templates/agents/detail.th.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<thlogic>
+  <attr sel="#header" th:replace="header :: header" />
+  <attr sel="#footer" th:replace="footer :: footer" />
+
+    <attr sel="#agent-info">
+      <attr sel="tbody" th:remove="all-but-first">
+        <attr sel="td.user-id" th:text="${agent.userId}" />
+        <attr sel="td.nickname" th:text="${agent.nickname}" />
+        <attr sel="td.agent-group" th:text="${agent.agentGroupName}" />
+      </attr>
+    </attr>
+
+    <attr sel="#client-table">
+      <attr sel="tbody" th:remove="all-but-first">
+        <attr sel="tr[0]" th:each="client : ${clients}">
+          <attr sel="td.client-id" th:text="${client.userId}" />
+          <attr sel="td.nickname" th:text="${client.nickname}" />
+          <attr sel="#client-manage" th:href="@{'/manage/' + ${client.userId}}" />
+        </attr>
+      </attr>
+    </attr>
+  </attr>
+</thlogic>

--- a/src/main/resources/templates/agents/index.html
+++ b/src/main/resources/templates/agents/index.html
@@ -101,7 +101,7 @@
     </div>
 
     <div class="row">
-      <table class="table" id="client-table">
+      <table class="table" id="agent-table">
         <thead>
         <tr>
           <th class="user-id col-2"><a>ID</a></th>
@@ -114,11 +114,11 @@
         </thead>
         <tbody>
         <tr>
-          <td class="user-id"><a>cocoballagent</a></td>
+          <td class="user-id">cocoballagent</td>
           <td class="nickname">김코코볼</td>
           <td class="agent-group">마케팅 1팀</td>
-          <td class="clients"><time>2022-08-18</time></td>
-          <td class="profile">상세 정보 확인</td>
+          <td class="created-at"><time>2022-08-18</time></td>
+          <td class="profile"><a class="btn btn-primary me-md-2" role="button" id="agent-info">상세 정보 확인</a></td>
           <td class="button"><a class="btn btn-danger me-md-2" role="button" id="agent-delete">삭제</a></td>
         </tr>
         <tr>
@@ -126,7 +126,7 @@
           <td>김지오</td>
           <td>마케팅 2팀</td>
           <td>2022-08-19</td>
-          <td class="profile">상세 정보 확인</td>
+          <td class="profile"><a class="btn btn-primary me-md-2" role="button" id="agent-info">상세 정보 확인</a></td>
           <td class="button"><a class="btn btn-danger me-md-2" role="button" id="agent-delete">삭제</a></td>
         </tr>
         <tr>
@@ -134,7 +134,7 @@
           <td>김흐압</td>
           <td>마케팅 5팀</td>
           <td>2022-08-20</td>
-          <td class="profile">상세 정보 확인</td>
+          <td class="profile"><a class="btn btn-primary me-md-2" role="button" id="agent-info">상세 정보 확인</a></td>
           <td class="button"><a class="btn btn-danger me-md-2" role="button" id="agent-delete">삭제</a></td>
         </tr>
         <tr>
@@ -142,7 +142,7 @@
           <td>김쾅쾅</td>
           <td>마케팅 본부</td>
           <td>2022-08-20</td>
-          <td class="profile">상세 정보 확인</td>
+          <td class="profile"><a class="btn btn-primary me-md-2" role="button" id="agent-info">상세 정보 확인</a></td>
           <td class="button"><a class="btn btn-danger me-md-2" role="button" id="agent-delete">삭제</a></td>
         </tr>
         <tr>
@@ -150,7 +150,7 @@
           <td>박쁑쁑</td>
           <td>마케팅 1팀</td>
           <td>2022-08-20</td>
-          <td class="profile">상세 정보 확인</td>
+          <td class="profile"><a class="btn btn-primary me-md-2" role="button" id="agent-info">상세 정보 확인</a></td>
           <td class="button"><a class="btn btn-danger me-md-2" role="button" id="agent-delete">삭제</a></td>
         </tr>
         <tr>
@@ -158,7 +158,7 @@
           <td>최쾅큥</td>
           <td>마케팅 2팀</td>
           <td>2022-08-20</td>
-          <td class="profile">상세 정보 확인</td>
+          <td class="profile"><a class="btn btn-primary me-md-2" role="button" id="agent-info">상세 정보 확인</a></td>
           <td class="button"><a class="btn btn-danger me-md-2" role="button" id="agent-delete">삭제</a></td>
         </tr>
         <tr>
@@ -166,7 +166,7 @@
           <td>김복동</td>
           <td>마케팅 3팀</td>
           <td>2022-08-20</td>
-          <td class="profile">상세 정보 확인</td>
+          <td class="profile"><a class="btn btn-primary me-md-2" role="button" id="agent-info">상세 정보 확인</a></td>
           <td class="button"><a class="btn btn-danger me-md-2" role="button" id="agent-delete">삭제</a></td>
         </tr>
         <tr>
@@ -174,7 +174,7 @@
           <td>김모찌</td>
           <td>마케팅 5팀</td>
           <td>2022-08-20</td>
-          <td class="profile">상세 정보 확인</td>
+          <td class="profile"><a class="btn btn-primary me-md-2" role="button" id="agent-info">상세 정보 확인</a></td>
           <td class="button"><a class="btn btn-danger me-md-2" role="button" id="agent-delete">삭제</a></td>
         </tr>
         <tr>
@@ -182,7 +182,7 @@
           <td>김호빵</td>
           <td>마케팅 3팀</td>
           <td>2022-08-20</td>
-          <td class="profile">상세 정보 확인</td>
+          <td class="profile"><a class="btn btn-primary me-md-2" role="button" id="agent-info">상세 정보 확인</a></td>
           <td class="button"><a class="btn btn-danger me-md-2" role="button" id="agent-delete">삭제</a></td>
         </tr>
         <tr>
@@ -190,7 +190,7 @@
           <td>김호떡</td>
           <td>마케팅 3팀</td>
           <td>2022-08-20</td>
-          <td class="profile">상세 정보 확인</td>
+          <td class="profile"><a class="btn btn-primary me-md-2" role="button" id="agent-info">상세 정보 확인</a></td>
           <td class="button"><a class="btn btn-danger me-md-2" role="button" id="agent-delete">삭제</a></td>
         </tr>
       </tbody>

--- a/src/main/resources/templates/agents/index.th.xml
+++ b/src/main/resources/templates/agents/index.th.xml
@@ -1,4 +1,66 @@
 <?xml version="1.0"?>
 <thlogic>
   <attr sel="#header" th:replace="header :: header" />
+
+  <attr sel="main" th:object="${agents}">
+    <attr sel="#search-form" th:action="@{/agents}" th:method="get" />
+    <attr sel="#search-type" th:remove="all-but-first">
+      <attr sel="option[0]"
+            th:each="searchType : ${searchTypes}"
+            th:value="${searchType.name}"
+            th:text="${searchType.description}"
+            th:selected="${param.searchType != null && (param.searchType.toString == searchType.name)}"
+      />
+    </attr>
+    <attr sel="#search-value" th:value="${param.searchValue}" />
+
+    <attr sel="#agent-table">
+      <attr sel="thead/tr">
+        <attr sel="th.user-id/a" th:text="'ID'" th:href="@{/agents(
+            page=${agents.number},
+            sort='userId' + (*{sort.getOrderFor('userId')} != null ? (*{sort.getOrderFor('userId').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${param.searchType},
+            searchValue=${param.searchValue}
+        )}"/>
+        <attr sel="th.nickname/a" th:text="'에이전트명'" th:href="@{/agents(
+            page=${agents.number},
+            sort='nickname' + (*{sort.getOrderFor('nickname')} != null ? (*{sort.getOrderFor('nickname').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${param.searchType},
+            searchValue=${param.searchValue}
+        )}"/>
+      </attr>
+
+      <attr sel="tbody" th:remove="all-but-first">
+        <attr sel="tr[0]" th:each="agent : ${agents}">
+          <attr sel="td.user-id" th:text="${agent.userId}" />
+          <attr sel="td.nickname" th:text="${agent.nickname}" />
+          <attr sel="td.agent-group" th:text="${agent.agentGroupName}" />
+          <attr sel="td.created-at/time" th:datetime="${agent.createdAt}" th:text="${#temporals.format(agent.createdAt, 'yyyy-MM-dd')}" />
+          <attr sel="#agent-info" th:href="@{'/agents/' + ${agent.userId}}" />
+          <attr sel="#agent-delete" th:action="@{'/agents/' + ${agent.userId}} + '/delete'" th:method="post" />
+        </attr>
+      </attr>
+    </attr>
+
+    <attr sel="#pagination">
+      <attr sel="li[0]/a"
+            th:text="'previous'"
+            th:href="@{/articles(page=${agents.number - 1}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
+            th:class="'page-link' + (${agents.number} <= 0 ? ' disabled' : '')"
+      />
+      <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
+        <attr sel="a"
+              th:text="${pageNumber + 1}"
+              th:href="@{/agents(page=${pageNumber}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
+              th:class="'page-link' + (${pageNumber} == ${agents.number} ? ' disabled' : '')"
+        />
+      </attr>
+      <attr sel="li[2]/a"
+            th:text="'next'"
+            th:href="@{/agents(page=${agents.number + 1}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
+            th:class="'page-link' + (${agents.number} >= ${agents.totalPages - 1} ? ' disabled' : '')"
+      />
+    </attr>
+  </attr>
+
 </thlogic>

--- a/src/test/java/com/agencyplatformclonecoding/controller/AgentControllerTest.java
+++ b/src/test/java/com/agencyplatformclonecoding/controller/AgentControllerTest.java
@@ -1,6 +1,8 @@
 package com.agencyplatformclonecoding.controller;
 
 import com.agencyplatformclonecoding.config.SecurityConfig;
+import com.agencyplatformclonecoding.domain.constrant.SearchType;
+import com.agencyplatformclonecoding.dto.*;
 import com.agencyplatformclonecoding.service.AgentService;
 import com.agencyplatformclonecoding.service.PaginationService;
 import org.junit.jupiter.api.DisplayName;
@@ -9,11 +11,23 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("VIEW 컨트롤러 - 에이전트 관리")
@@ -39,27 +53,63 @@ class AgentControllerTest {
     @Test
     public void givenNothing_whenRequestingAgentsView_thenReturnsAgentsView() throws Exception {
         // Given
+		given(agentService.searchAgents(eq(null), eq(null), any(Pageable.class))).willReturn(Page.empty());
+        given(paginationService.getPaginationBarNumbers(anyInt(), anyInt())).willReturn(List.of(0,1,2,3,4));
 
         // When & Then
         mvc.perform(get("/agents"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("agents/index"))
-                .andExpect(model().attributeExists("agents"));
+                .andExpect(model().attributeExists("agents"))
+				.andExpect(model().attributeExists("paginationBarNumbers"));
+		then(agentService).should().searchAgents(eq(null), eq(null), any(Pageable.class));
+		then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
+    }
+
+    @DisplayName("[VIEW][GET] 에이전트 리스트 - 검색어와 함께 호출")
+    @Test
+    public void givenSearchKeyword_whenSearchingAgentsView_thenReturnsAgentsView() throws Exception {
+        // Given
+		SearchType searchType = SearchType.NICKNAME;
+		String searchValue = "name";
+		given(agentService.searchAgents(eq(searchType), eq(searchValue), any(Pageable.class))).willReturn(Page.empty());
+        given(paginationService.getPaginationBarNumbers(anyInt(), anyInt())).willReturn(List.of(0,1,2,3,4));
+
+        // When & Then
+        mvc.perform(
+				get("/agents")
+						.queryParam("searchType", searchType.name())
+						.queryParam("searchValue", searchValue)
+				)
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("agents/index"))
+                .andExpect(model().attributeExists("agents"))
+				.andExpect(model().attributeExists("searchTypes"));
+		then(agentService).should().searchAgents(eq(searchType), eq(searchValue), any(Pageable.class));
+		then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
     }
 
     @DisplayName("[VIEW][GET] 에이전트 상세 정보 - 정상 호출")
     @Test
     public void givenNothing_whenRequestingAgentDetailView_thenReturnsAgentDetailView() throws Exception {
         // Given
+		String agentId = "agent";
+		Long totalCount = 1L;
+		given(agentService.getAgentWithClients(agentId)).willReturn(createAgentWithClientsDto());
+		given(agentService.getAgentCount()).willReturn(totalCount);
 
         // When & Then
-        mvc.perform(get("/agents/agent1"))
+        mvc.perform(get("/agents/" + agentId))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("agents/detail"))
                 .andExpect(model().attributeExists("agent"))
-                .andExpect(model().attributeExists("clients"));
+                .andExpect(model().attributeExists("clients"))
+				.andExpect(model().attribute("totalCount", totalCount));
+		then(agentService).should().getAgentWithClients(agentId);
+		then(agentService).should().getAgentCount();
     }
 
     @DisplayName("[VIEW][GET] 에이전트 상세 정보 -> 담당 광고주의 캠페인 관리 페이지로 리다이렉션")
@@ -73,5 +123,106 @@ class AgentControllerTest {
                 .andExpect(view().name("forward:/manage/{clientId}"))
                 .andExpect(forwardedUrl("/manage/{clientId}"))
                 .andDo(MockMvcResultHandlers.print());
+    }
+
+    //0824 추가
+   	@DisplayName("[VIEW][GET] 에이전트 페이지 - 페이징, 정렬 기능")
+    @Test
+    void givenPagingAndSortingParams_whenSearchingAgentsPage_thenReturnsAgentsView() throws Exception {
+        // Given
+        String sortName = "title";
+        String direction = "desc";
+        int pageNumber = 0;
+        int pageSize = 5;
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Order.desc(sortName)));
+        List<Integer> barNumbers = List.of(1, 2, 3, 4, 5);
+        given(agentService.searchAgents(null, null, pageable)).willReturn(Page.empty());
+        given(paginationService.getPaginationBarNumbers(pageable.getPageNumber(), Page.empty().getTotalPages())).willReturn(barNumbers);
+
+        // When & Then
+        mvc.perform(
+                get("/agents")
+                        .queryParam("page", String.valueOf(pageNumber))
+                        .queryParam("size", String.valueOf(pageSize))
+                        .queryParam("sort", sortName + "," + direction)
+                   )
+                   .andExpect(status().isOk())
+                   .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                   .andExpect(view().name("agents/index"))
+                   .andExpect(model().attributeExists("agents"))
+                   .andExpect(model().attribute("paginationBarNumbers", barNumbers));
+        then(agentService).should().searchAgents(null, null, pageable);
+        then(paginationService).should().getPaginationBarNumbers(pageable.getPageNumber(), Page.empty().getTotalPages());
+    }
+
+   	//0824 추가
+   	/* @DisplayName("[VIEW][POST] 에이전트 삭제 - 정상 호출")
+   	@Test
+   	void givenAgentIdToDelete_whenRequesting_thenDeletesAgent() throws Exception {
+   		// Given
+   		String agentId = "t-agent";
+   		willDoNothing().given(agentService).deleteAgent(agentId);
+
+   		// When & Then
+   		mvc.perform(
+   						post("/agents/" + agentId + "/delete")
+   								.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+   								.with(csrf())
+   				)
+   				.andExpect(status().is3xxRedirection())
+   				.andExpect(view().name("redirect::/agents"))
+   				.andExpect(redirectedUrl("/agents"));
+   		then(agentService).should().deleteAgenct(agentId);
+   } */
+
+    // fixture
+
+    private AgencyDto createAgencyDto() {
+        return AgencyDto.of(
+                "t-agency",
+                "테스트용"
+        );
+    }
+
+    private AgentGroupDto createAgentGroupDto() {
+        return AgentGroupDto.of(
+                createAgencyDto(),
+                "t-group",
+                "테스트용",
+                LocalDateTime.now(),
+                "테스트",
+                LocalDateTime.now(),
+                "테스트"
+        );
+    }
+    private AgentDto createAgentDto() {
+        return AgentDto.of(
+                createAgencyDto(),
+                createAgentGroupDto(),
+                "t-agent",
+                "pw",
+                "테스트용용",
+                "email",
+                LocalDateTime.now(),
+                "테스트",
+                LocalDateTime.now(),
+                "테스트"
+        );
+    }
+
+    private AgentWithClientsDto createAgentWithClientsDto() {
+        return AgentWithClientsDto.of(
+                createAgencyDto(),
+                createAgentGroupDto(),
+                Set.of(),
+                "t-client",
+                "pw",
+                "김테스트",
+                "email",
+                LocalDateTime.now(),
+                "테스트",
+                LocalDateTime.now(),
+                "테스트"
+        );
     }
 }

--- a/src/test/java/com/agencyplatformclonecoding/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/agencyplatformclonecoding/repository/JpaRepositoryTest.java
@@ -54,7 +54,7 @@ class JpaRepositoryTest {
 
         // Then
         assertThat(agentGroups).isNotNull().hasSize(5);
-        assertThat(agents).isNotNull().hasSize(20);
+        assertThat(agents).isNotNull().hasSize(21);
         assertThat(clientUsers).isNotNull().hasSize(100);
         assertThat(campaigns).isNotNull().hasSize(200);
         assertThat(creatives).isNotNull().hasSize(1000);

--- a/src/test/java/com/agencyplatformclonecoding/service/AgentGroupServiceTest.java
+++ b/src/test/java/com/agencyplatformclonecoding/service/AgentGroupServiceTest.java
@@ -1,0 +1,389 @@
+package com.agencyplatformclonecoding.service;
+
+import com.agencyplatformclonecoding.domain.Agency;
+import com.agencyplatformclonecoding.domain.Agent;
+import com.agencyplatformclonecoding.domain.AgentGroup;
+import com.agencyplatformclonecoding.domain.ClientUser;
+import com.agencyplatformclonecoding.domain.constrant.SearchType;
+import com.agencyplatformclonecoding.dto.*;
+import com.agencyplatformclonecoding.repository.AgencyRepository;
+import com.agencyplatformclonecoding.repository.AgentGroupRepository;
+import com.agencyplatformclonecoding.repository.AgentRepository;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import javax.persistence.EntityNotFoundException;
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.catchThrowable;
+import static org.mockito.BDDMockito.*;
+
+@DisplayName("비즈니스 로직 - 에이전트 그룹 관리")
+@ExtendWith(MockitoExtension.class)
+class AgentGroupServiceTest {
+
+	@InjectMocks private AgentGroupService sut;
+
+	@Mock private AgencyRepository agencyRepository;
+	@Mock private AgentGroupRepository agentGroupRepository;
+	@Mock private AgentRepository agentRepository;
+
+	@DisplayName("READ - 에이전트 그룹 조회 시 에이전트 그룹 반환")
+	@Test
+	void givenAgentGroupId_whenSearchingAgentGroup_thenReturnsAgentGroup() {
+		// Given
+		String agentGroupId = "t-group";
+		AgentGroup agentGroup = createAgentGroup();
+		given(agentGroupRepository.findById(agentGroupId)).willReturn(Optional.of(agentGroup));
+
+		// When
+		AgentGroupDto dto = sut.getAgentGroup(agentGroupId);
+
+		// Then
+		assertThat(dto)
+				.hasFieldOrPropertyWithValue("name", agentGroup.getName());
+		then(agentGroupRepository).should().findById(agentGroupId);
+	}
+
+	@DisplayName("READ - 검색어 없이 에이전트 그룹 검색 시 에이전트 그룹 페이지 반환")
+	@Test
+	void givenNoSearchingParameters_whenSearchingAgentGroup_thenReturnsAgentGroupPage() {
+		// Given
+		Pageable pageable = Pageable.ofSize(20);
+		given(agentGroupRepository.findAll(pageable)).willReturn(Page.empty());
+
+		// When
+		Page<AgentGroupDto> agentGroups = sut.searchAgentGroups(null, null, pageable);
+
+		// Then
+		assertThat(agentGroups).isEmpty();
+		then(agentGroupRepository).should().findAll(pageable);
+	}
+
+	@DisplayName("READ - 검색어와 함께 에이전트 그룹 검색 시 에이전트 그룹 페이지 반환")
+	@Test
+	void givenSearchingParameters_whenSearchingAgentGroup_thenReturnsAgentGroupPage() {
+		// Given
+		SearchType searchType = SearchType.NICKNAME;
+		String searchKeyword = "테스트";
+		Pageable pageable = Pageable.ofSize(20);
+		given(agentGroupRepository.findByNameContaining(searchKeyword, pageable)).willReturn(Page.empty());
+
+		// When
+		Page<AgentGroupDto> agentGroups = sut.searchAgentGroups(searchType, searchKeyword, pageable);
+
+		// Then
+		assertThat(agentGroups).isEmpty();
+		then(agentGroupRepository).should().findByNameContaining(searchKeyword, pageable);
+	}
+
+	@DisplayName("READ - 에이전트 그룹 ID 조회 시 에이전트 그룹과 소속된 광고주 리스트 페이지 반환")
+	@Test
+	void givenAgentGroupId_whenSearchingAgentGroupWithAgents_thenReturnsAgentGroupWithAgents() {
+		// Given
+		String agentGroupId = "t-group";
+		AgentGroup agentGroup = createAgentGroup();
+		given(agentGroupRepository.findById(agentGroupId)).willReturn(Optional.of(agentGroup));
+
+		// When
+		AgentGroupWithAgentsDto dto = sut.getAgentGroupWithAgents(agentGroupId);
+
+		// Then
+		assertThat(dto)
+				.hasFieldOrPropertyWithValue("name", agentGroup.getName());
+		then(agentGroupRepository).should().findById(agentGroupId);
+	}
+
+	@DisplayName("READ - 에이전트 그룹이 없을 경우 예외 처리")
+    @Test
+    void givenNonexistentAgentGroupId_whenSearchingAgentGroup_thenThrowsException() {
+        // Given
+        String agentGroupId = "null";
+        given(agentGroupRepository.findById(agentGroupId)).willReturn(Optional.empty());
+
+        // When
+        Throwable t = catchThrowable(() -> sut.getAgentGroup(agentGroupId));
+
+        // Then
+        assertThat(t)
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("에이전트 그룹이 존재하지 않습니다 - agentGroupId : " + agentGroupId);
+        then(agentGroupRepository).should().findById(agentGroupId);
+    }
+
+	@DisplayName("READ - 에이전트가 소속된 에이전트 그룹이 없을 경우 예외 처리")
+    @Test
+    void givenNonexistentAgentGroupId_whenSearchingAgentGroupWithAgents_thenThrowsException() {
+        // Given
+        String agentGroupId = "null";
+        given(agentGroupRepository.findById(agentGroupId)).willReturn(Optional.empty());
+
+        // When
+        Throwable t = catchThrowable(() -> sut.getAgentGroupWithAgents(agentGroupId));
+
+        // Then
+        assertThat(t)
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("에이전트 그룹이 존재하지 않습니다 - agentGroupId : " + agentGroupId);
+        then(agentGroupRepository).should().findById(agentGroupId);
+    }
+
+	@DisplayName("CREATE - 에이전트 그룹 정보 입력 시 에이전트 그룹 생성")
+    @Test
+    void givenAgentGroupInfo_whenSavingAgentGroup_thenSavesAgentGroup() {
+        // Given
+        AgentGroupDto dto = createAgentGroupDto();
+		given(agencyRepository.getReferenceById(dto.agencyDto().agencyId())).willReturn(createAgency());
+		given(agentGroupRepository.save(any(AgentGroup.class))).willReturn(createAgentGroup());
+
+        // When
+        sut.saveAgentGroup(dto);
+
+        // Then
+        then(agencyRepository).should().getReferenceById(dto.agencyDto().agencyId());
+		then(agentGroupRepository).should().save(any(AgentGroup.class));
+    }
+
+    @DisplayName("CREATE - 에이전트 그룹 ID와 에이전트 정보 입력 시 에이전트 그룹 내 에이전트 생성")
+    @Test
+    void givenAgentGroupIdAndAgentInfo_whenSavingAgentGroup_thenSavesAgentGroup() {
+        // Given
+        AgentDto dto = createAgentDto();
+   		String agentGroupId = "t-group";
+   		given(agencyRepository.getReferenceById(dto.agencyDto().agencyId())).willReturn(createAgency());
+   		given(agentGroupRepository.getReferenceById(dto.agentGroupDto().id())).willReturn(createAgentGroup());
+   		given(agentRepository.save(any(Agent.class))).willReturn(createAgent());
+
+        // When
+        sut.saveAgentInAgentGroup(agentGroupId, dto);
+
+        // Then
+        then(agencyRepository).should().getReferenceById(dto.agencyDto().agencyId());
+   	    then(agentGroupRepository).should().getReferenceById(dto.agentGroupDto().id());
+   		then(agentRepository).should().save(any(Agent.class));
+    }
+
+	@DisplayName("UPDATE - 에이전트 그룹 이름 수정 정보 입력 시 에이전트 그룹 이름 수정")
+    @Test
+    void givenAgentGroupModifiedName_whenUpdatingAgentGroupName_thenUpdatesAgentGroupName() {
+        // Given
+		AgentGroup agentGroup = createAgentGroup();
+		AgentGroupDto dto = createAgentGroupDto("update-group");
+		given(agentGroupRepository.getReferenceById(dto.id())).willReturn(agentGroup);
+		given(agencyRepository.getReferenceById(dto.agencyDto().agencyId())).willReturn(dto.agencyDto().toEntity());
+
+        // When
+        sut.updateAgentGroup(dto.id(), dto);
+
+        // Then
+		assertThat(agentGroup)
+				.hasFieldOrPropertyWithValue("name", dto.name());
+        then(agentGroupRepository).should().getReferenceById(dto.id());
+        then(agencyRepository).should().getReferenceById(dto.agencyDto().agencyId());
+    }
+
+	@DisplayName("UPDATE - 존재하지 않는 에이전트 그룹을 수정하려고 할 경우 경고 로그 출력")
+    @Test
+    void givenNotExistAgentGroup_whenUpdatingAgentGroupName_thenLogsWarningAndDoesNothing() {
+        // Given
+		AgentGroupDto dto = createAgentGroupDto("update-group");
+		given(agentGroupRepository.getReferenceById(dto.id())).willThrow(EntityNotFoundException.class);
+
+        // When
+        sut.updateAgentGroup(dto.id(), dto);
+
+        // Then
+		then(agentGroupRepository).should().getReferenceById(dto.id());
+    }
+
+	@DisplayName("DELETE - 에이전트 그룹의 ID 입력 시 에이전트 그룹을 삭제 - 정상 호출(소속 에이전트 없는 경우)")
+    @Test
+    void givenAgentGroupId_whenDeletingAgentGroup_thenDeleteAgentGroup() {
+		// Given
+        String agentGroupId = "t-group";
+        willDoNothing().given(agentGroupRepository).deleteAgentGroupById(agentGroupId);
+
+        // When
+        sut.deleteAgentGroup(agentGroupId);
+
+        // Then
+        then(agentGroupRepository).should().deleteAgentGroupById(agentGroupId);
+    }
+
+    @Disabled("")
+	@DisplayName("DELETE - 존재하지 않는 에이전트 그룹의 ID로 삭제 요청 시 경고 로그 출력")
+    @Test
+    void givenNotExistAgentGroupId_whenDeletingAgentGroup_thenLogsWarningAndDoesNothing() {
+		// Given
+        String agentGroupId = "t-group";
+        // given(agentGroupRepository).deleteAgentGroupById(agentGroupId).willThrow(EntityNotFoundException.class);
+
+        // When
+        sut.deleteAgentGroup(agentGroupId);
+
+        // Then
+        then(agentGroupRepository).should().deleteAgentGroupById(agentGroupId);
+    }
+
+    @Disabled("")
+	@DisplayName("DELETE - 에이전트가 남아 있는 에이전트 그룹 ID로 삭제 요청 시 경고 로그 출력")
+    @Test
+    void givenHavingAgentsAgentGroupId_whenDeletingAgentGroup_thenLogsWarningAndDoesNothing() {
+		// Given
+        String agentGroupId = "t-group";
+        // given(agentGroupRepository).deleteAgentGroupById(agentGroupId).willThrow(IllegalArgumentException.class);
+
+        // When
+        sut.deleteAgentGroup(agentGroupId);
+
+        // Then
+        then(agentGroupRepository).should().deleteById(agentGroupId);
+    }
+
+	@DisplayName("READ - 에이전트 그룹 수를 조회하면, 에이전트 그룹 수를 반환한다")
+    @Test
+    void givenNothing_whenCountingAgentGroups_thenReturnsAgentGroupCount() {
+        // Given
+        long expected = 0L;
+        given(agentGroupRepository.count()).willReturn(expected);
+
+        // When
+        long actual = sut.getAgentGroupCount();
+
+        // Then
+        assertThat(actual).isEqualTo(expected);
+        then(agentGroupRepository).should().count();
+    }
+
+	@DisplayName("READ - 에이전트 그룹 내부 에이전트 수를 조회하면, 에이전트 수를 반환한다")
+    @Test
+    void givenAgentGroupId_whenCountingAgentsInAgentGroup_thenReturnsAgentCount() {
+        // Given
+		String agentGroupId = "t-group";
+        given(agentRepository.findByAgentGroup_Id(agentGroupId)).willReturn(Collections.emptyList());
+        int expected = 0;
+
+        // When
+        int actual = sut.getAgentCount(agentGroupId);
+
+        // Then
+        assertThat(actual).isEqualTo(expected);
+		then(agentRepository).should().findByAgentGroup_Id(agentGroupId);
+    }
+
+	// fixture
+
+ private Agency createAgency() {
+     Agency agency = Agency.of(
+             "t-agency",
+             "테스트용"
+     );
+
+     return agency;
+ }
+
+ private AgentGroup createAgentGroup() {
+     AgentGroup agentGroup = AgentGroup.of(
+             createAgency(),
+             "t-group",
+             "테스트용그룹"
+     );
+
+     return agentGroup;
+ }
+
+ private Agent createAgent() {
+     Agent agent = Agent.of(
+             createAgency(),
+             createAgentGroup(),
+             "t-agent",
+             "pw",
+             "email",
+             "테스트용"
+     );
+
+     return agent;
+ }
+
+ private ClientUser createClientUser() {
+     ClientUser clientUser = ClientUser.of(
+             createAgency(),
+             createAgent(),
+             "t-client",
+             "pw",
+             "email",
+             "테스트용"
+     );
+
+     return clientUser;
+ }
+
+ private List<ClientUser> clientUsers() {
+     List<ClientUser> clientUsers = Arrays.asList(createClientUser());
+
+     return clientUsers;
+ }
+
+ private AgencyDto createAgencyDto() {
+     return AgencyDto.of(
+             "t-agency",
+             "테스트용"
+     );
+ }
+
+ private AgentGroupDto createAgentGroupDto() {
+        return createAgentGroupDto("update-group");
+ }
+
+ private AgentGroupDto createAgentGroupDto(String agentGroupName) {
+     return AgentGroupDto.of(
+             createAgencyDto(),
+             "t-group",
+             agentGroupName,
+             LocalDateTime.now(),
+             "테스트",
+             LocalDateTime.now(),
+             "테스트"
+     );
+ }
+ private AgentDto createAgentDto() {
+     return AgentDto.of(
+             createAgencyDto(),
+             createAgentGroupDto(),
+             "t-agent",
+             "pw",
+             "테스트용용",
+             "email",
+             LocalDateTime.now(),
+             "테스트",
+             LocalDateTime.now(),
+             "테스트"
+     );
+ }
+
+ private AgentWithClientsDto createAgentWithClientsDto() {
+     return AgentWithClientsDto.of(
+             createAgencyDto(),
+             createAgentGroupDto(),
+             Set.of(),
+             "t-agent",
+             "pw",
+             "김테스트",
+             "email",
+             LocalDateTime.now(),
+             "테스트",
+             LocalDateTime.now(),
+             "테스트"
+     );
+ }
+
+}

--- a/src/test/java/com/agencyplatformclonecoding/service/AgentServiceTest.java
+++ b/src/test/java/com/agencyplatformclonecoding/service/AgentServiceTest.java
@@ -1,0 +1,352 @@
+package com.agencyplatformclonecoding.service;
+
+import com.agencyplatformclonecoding.domain.Agency;
+import com.agencyplatformclonecoding.domain.Agent;
+import com.agencyplatformclonecoding.domain.AgentGroup;
+import com.agencyplatformclonecoding.domain.ClientUser;
+import com.agencyplatformclonecoding.domain.constrant.SearchType;
+import com.agencyplatformclonecoding.dto.AgencyDto;
+import com.agencyplatformclonecoding.dto.AgentDto;
+import com.agencyplatformclonecoding.dto.AgentGroupDto;
+import com.agencyplatformclonecoding.dto.AgentWithClientsDto;
+import com.agencyplatformclonecoding.repository.AgencyRepository;
+import com.agencyplatformclonecoding.repository.AgentGroupRepository;
+import com.agencyplatformclonecoding.repository.AgentRepository;
+import com.agencyplatformclonecoding.repository.ClientUserRepository;
+import net.bytebuddy.implementation.bytecode.Throw;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import javax.persistence.EntityNotFoundException;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@DisplayName("비즈니스 로직 - 에이전트 관리")
+@ExtendWith(MockitoExtension.class)
+class AgentServiceTest {
+
+    @InjectMocks private AgentService sut;
+
+    @Mock private AgentRepository agentRepository;
+    @Mock private AgentGroupRepository agentGroupRepository;
+    @Mock private AgencyRepository agencyRepository;
+    @Mock private ClientUserRepository clientUserRepository;
+
+    @DisplayName("READ - 에이전트 조회 시 에이전트 반환")
+    @Test
+    void givenAgentId_whenSearchingAgent_thenReturnsAgent() {
+        // Given
+        String agentId = "t-agent";
+        Agent agent = createAgent();
+        given(agentRepository.findById(agentId)).willReturn(Optional.of(agent));
+
+        // When
+        AgentDto dto = sut.getAgent(agentId);
+
+        // Then
+        assertThat(dto)
+                .hasFieldOrPropertyWithValue("userId", agent.getUserId())
+                .hasFieldOrPropertyWithValue("nickname", agent.getNickname());
+        then(agentRepository).should().findById(agentId);
+    }
+
+    @DisplayName("READ - 검색어 없이 검색 시 에이전트 리스트를 반환")
+    @Test
+    void givenNoSearchingParameter_whenSearchingAgents_thenReturnsAgentPage() {
+        // Given
+        Pageable pageable = Pageable.ofSize(20);
+        given(agentRepository.findAll(pageable)).willReturn(Page.empty());
+
+        // When
+        Page<AgentDto> agents = sut.searchAgents(null, null, pageable);
+
+        // Then
+        assertThat(agents).isEmpty();
+        then(agentRepository).should().findAll(pageable);
+    }
+
+    @DisplayName("READ - 검색어를 통해 에이전트 검색 시 에이전트 리스트를 반환")
+    @Test
+    void givenSearchingParameter_whenSearchingAgents_thenReturnsAgentPage() {
+        // Given
+        SearchType searchType = SearchType.ID;
+        String searchKeyword = "t-agent";
+        Pageable pageable = Pageable.ofSize(20);
+        given(agentRepository.findByUserIdContaining(searchKeyword, pageable)).willReturn(Page.empty());
+
+        // When
+        Page<AgentDto> agents = sut.searchAgents(searchType, searchKeyword, pageable);
+
+        // Then
+        assertThat(agents).isEmpty();
+        then(agentRepository).should().findByUserIdContaining(searchKeyword, pageable);
+    }
+
+    @DisplayName("READ - 에이전트 조회 시 에이전트에 매핑된 광고주 리스트 반환")
+    @Test
+    void givenAgentId_whenSearchingAgentWithClients_thenReturnsAgentWithClients() {
+        // Given
+        String agentId = "t-agent";
+        Agent agent = createAgent();
+        given(agentRepository.findById(agentId)).willReturn(Optional.of(agent));
+
+        // When
+        AgentWithClientsDto dto = sut.getAgentWithClients(agentId);
+
+        // Then
+        assertThat(dto)
+                .hasFieldOrPropertyWithValue("userId", agent.getUserId())
+                .hasFieldOrPropertyWithValue("nickname", agent.getNickname());
+        then(agentRepository).should().findById(agentId);
+    }
+
+    @DisplayName("READ - 광고주를 매핑한 에이전트가 없을 경우 예외 처리")
+    @Test
+    void givenNonexistentAgentId_whenSearchingAgentWithClients_thenReturnsAgentWithClients() {
+        // Given
+        String agentId = "none-agent";
+        given(agentRepository.findById(agentId)).willReturn(Optional.empty());
+
+        // When
+        Throwable t= catchThrowable(() -> sut.getAgentWithClients(agentId));
+
+        // Then
+        assertThat(t)
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("에이전트가 존재하지 않습니다 - agentId : " + agentId);
+        then(agentRepository).should().findById(agentId);
+    }
+
+    @DisplayName("READ - 에이전트가 없을 경우 예외 처리")
+    @Test
+    void givenNonexistentAgentId_whenSearchingAgent_thenThrowsException() {
+        // Given
+        String agentId = "none-agent";
+        given(agentRepository.findById(agentId)).willReturn(Optional.empty());
+
+        // When
+        Throwable t= catchThrowable(() -> sut.getAgent(agentId));
+
+        // Then
+        assertThat(t)
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("에이전트가 존재하지 않습니다 - agentId : " + agentId);
+        then(agentRepository).should().findById(agentId);
+    }
+
+    @DisplayName("DELETE - 에이전트 ID 입력 시 에이전트를 삭제 - 정상 (매핑된 광고주가 없을 시)")
+    @Test
+    void givenNotMappingClientsAgentId_whenDeletingAgent_thenDeleteAgent() {
+        // Given
+        String agentId = "test";
+        willDoNothing().given(agentRepository).deleteAgentByUserId(agentId);
+
+        // When
+        sut.deleteAgent(agentId);
+
+        // Then
+        then(agentRepository).should().deleteAgentByUserId(agentId);
+    }
+
+    @Disabled("에이전트-광고주 매핑 관계를 테스트에 넣는 방법 확인 필요")
+    @DisplayName("DELETE - 에이전트 ID 입력 시 에이전트를 삭제 - 예외 처리 (매핑된 광고주가 있을 경우)")
+    @Test
+    void givenMappingClientsAgentId_whenDeletingAgent_thenThrowsException() {
+        // Given
+        Agent agent = createAgent();
+        String agentId = agent.getUserId();
+        List<ClientUser> clientUsers = clientUsers();
+        given(clientUserRepository.findByAgent_UserId(agentId)).willReturn(clientUsers);
+        willDoNothing().given(agentRepository).deleteAgentByUserId(agentId);
+
+        // When
+        Throwable t = catchThrowable(() -> sut.deleteAgent(agentId));
+
+        // Then
+        assertThat(t)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("매핑된 광고주가 있어 삭제가 불가능합니다 - agentId : " + agentId);
+        then(agentRepository).should().deleteAgentByUserId(agentId);
+    }
+
+    @Disabled("에이전트-광고주 매핑 관계를 테스트에 넣는 방법 확인 필요")
+    @DisplayName("DELETE - 에이전트 ID 입력 시 에이전트를 삭제 - 예외 처리 (존재하지 않는 에이전트 ID)")
+    @Test
+    void givenWrongClientsAgentId_whenDeletingAgent_thenThrowsException() {
+        // Given
+        String agentId = "none-agent";
+        given(agentRepository.findById(agentId)).willReturn(Optional.empty());
+        willDoNothing().given(agentRepository).deleteAgentByUserId(agentId);
+
+        // When
+        Throwable t= catchThrowable(() -> sut.deleteAgent(agentId));
+
+        // Then
+        assertThat(t)
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("에이전트가 존재하지 않습니다 - agentId : " + agentId);
+        then(agentRepository).should().deleteAgentByUserId(agentId);
+    }
+
+    @DisplayName("READ - 에이전트 수를 조회하면, 에이전트트 수를반환한다")
+    @Test
+    void givenNothing_whenCountingAgents_thenReturnsAgentsCount() {
+        // Given
+        long expected = 0L;
+        given(agentRepository.count()).willReturn(expected);
+
+        // When
+        long actual = sut.getAgentCount();
+
+        // Then
+        assertThat(actual).isEqualTo(expected);
+        then(agentRepository).should().count();
+    }
+
+
+    // fixture
+
+    private Agency createAgency() {
+        Agency agency = Agency.of(
+                "t-agency",
+                "테스트용"
+        );
+
+        return agency;
+    }
+
+    private AgentGroup createAgentGroup() {
+        AgentGroup agentGroup = AgentGroup.of(
+                createAgency(),
+                "t-group",
+                "테스트용그룹"
+        );
+
+        return agentGroup;
+    }
+
+    private Agent createAgent() {
+        Agent agent = Agent.of(
+                createAgency(),
+                createAgentGroup(),
+                "t-agent",
+                "pw",
+                "email",
+                "테스트용"
+        );
+
+        return agent;
+    }
+
+    private ClientUser createClientUser() {
+        ClientUser clientUser = ClientUser.of(
+                createAgency(),
+                createAgent(),
+                "t-client",
+                "pw",
+                "email",
+                "테스트용"
+        );
+
+        return clientUser;
+    }
+
+    private List<ClientUser> clientUsers() {
+        List<ClientUser> clientUsers = Arrays.asList(createClientUser());
+
+        return clientUsers;
+    }
+
+    private AgencyDto createAgencyDto() {
+        return AgencyDto.of(
+                "t-agency",
+                "테스트용"
+        );
+    }
+
+    private AgentGroupDto createAgentGroupDto() {
+        return AgentGroupDto.of(
+                createAgencyDto(),
+                "t-group",
+                "테스트용",
+                LocalDateTime.now(),
+                "테스트",
+                LocalDateTime.now(),
+                "테스트"
+        );
+    }
+
+    private AgentGroupDto createModifiedAgentGroupDto(String agentGroupId) {
+        return AgentGroupDto.of(
+                createAgencyDto(),
+                agentGroupId,
+                "테스트용",
+                LocalDateTime.now(),
+                "테스트",
+                LocalDateTime.now(),
+                "테스트"
+        );
+    }
+    private AgentDto createAgentDto() {
+        return AgentDto.of(
+                createAgencyDto(),
+                createAgentGroupDto(),
+                "t-agent",
+                "pw",
+                "테스트용용",
+                "email",
+                LocalDateTime.now(),
+                "테스트",
+                LocalDateTime.now(),
+                "테스트"
+        );
+    }
+
+    private AgentDto createAgentDto(String agentGroupId) {
+        return AgentDto.of(
+                createAgencyDto(),
+                createModifiedAgentGroupDto(agentGroupId),
+                "t-agent",
+                "pw",
+                "테스트용용",
+                "email",
+                LocalDateTime.now(),
+                "테스트",
+                LocalDateTime.now(),
+                "테스트"
+        );
+    }
+
+    private AgentWithClientsDto createAgentWithClientsDto() {
+        return AgentWithClientsDto.of(
+                createAgencyDto(),
+                createAgentGroupDto(),
+                Set.of(),
+                "t-agent",
+                "pw",
+                "김테스트",
+                "email",
+                LocalDateTime.now(),
+                "테스트",
+                LocalDateTime.now(),
+                "테스트"
+        );
+    }
+
+}

--- a/src/test/java/com/agencyplatformclonecoding/service/AgentServiceTest.java
+++ b/src/test/java/com/agencyplatformclonecoding/service/AgentServiceTest.java
@@ -13,7 +13,6 @@ import com.agencyplatformclonecoding.repository.AgencyRepository;
 import com.agencyplatformclonecoding.repository.AgentGroupRepository;
 import com.agencyplatformclonecoding.repository.AgentRepository;
 import com.agencyplatformclonecoding.repository.ClientUserRepository;
-import net.bytebuddy.implementation.bytecode.Throw;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,7 +22,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import javax.persistence.EntityNotFoundException;
 import java.time.LocalDateTime;
@@ -34,7 +32,6 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 @DisplayName("비즈니스 로직 - 에이전트 관리")
@@ -155,13 +152,13 @@ class AgentServiceTest {
     void givenNotMappingClientsAgentId_whenDeletingAgent_thenDeleteAgent() {
         // Given
         String agentId = "test";
-        willDoNothing().given(agentRepository).deleteAgentByUserId(agentId);
+        willDoNothing().given(agentRepository).deleteByUserId(agentId);
 
         // When
         sut.deleteAgent(agentId);
 
         // Then
-        then(agentRepository).should().deleteAgentByUserId(agentId);
+        then(agentRepository).should().deleteByUserId(agentId);
     }
 
     @Disabled("에이전트-광고주 매핑 관계를 테스트에 넣는 방법 확인 필요")
@@ -173,7 +170,7 @@ class AgentServiceTest {
         String agentId = agent.getUserId();
         List<ClientUser> clientUsers = clientUsers();
         given(clientUserRepository.findByAgent_UserId(agentId)).willReturn(clientUsers);
-        willDoNothing().given(agentRepository).deleteAgentByUserId(agentId);
+        willDoNothing().given(agentRepository).deleteByUserId(agentId);
 
         // When
         Throwable t = catchThrowable(() -> sut.deleteAgent(agentId));
@@ -182,7 +179,7 @@ class AgentServiceTest {
         assertThat(t)
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("매핑된 광고주가 있어 삭제가 불가능합니다 - agentId : " + agentId);
-        then(agentRepository).should().deleteAgentByUserId(agentId);
+        then(agentRepository).should().deleteByUserId(agentId);
     }
 
     @Disabled("에이전트-광고주 매핑 관계를 테스트에 넣는 방법 확인 필요")
@@ -192,7 +189,7 @@ class AgentServiceTest {
         // Given
         String agentId = "none-agent";
         given(agentRepository.findById(agentId)).willReturn(Optional.empty());
-        willDoNothing().given(agentRepository).deleteAgentByUserId(agentId);
+        willDoNothing().given(agentRepository).deleteByUserId(agentId);
 
         // When
         Throwable t= catchThrowable(() -> sut.deleteAgent(agentId));
@@ -201,7 +198,7 @@ class AgentServiceTest {
         assertThat(t)
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessage("에이전트가 존재하지 않습니다 - agentId : " + agentId);
-        then(agentRepository).should().deleteAgentByUserId(agentId);
+        then(agentRepository).should().deleteByUserId(agentId);
     }
 
     @DisplayName("READ - 에이전트 수를 조회하면, 에이전트트 수를반환한다")

--- a/src/test/java/com/agencyplatformclonecoding/service/PaginationServiceTest.java
+++ b/src/test/java/com/agencyplatformclonecoding/service/PaginationServiceTest.java
@@ -1,0 +1,72 @@
+package com.agencyplatformclonecoding.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+@DisplayName("비즈니스 로직 - 페이지네이션")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = PaginationService.class) // 테스트의 무게가 줄어듬
+class PaginationServiceTest {
+
+    private final PaginationService sut;
+
+       public PaginationServiceTest(@Autowired PaginationService paginationService) {
+           this.sut = paginationService;
+       }
+
+       @DisplayName("현재 페이지 번호와 총 페이지 수를 주면, 페이지 바 리스트를 만들어줌")
+       @MethodSource // 메소드에 소스를 주는 방식
+       @ParameterizedTest(name = "[{index}] 현재 페이지 : {0}, 총 페이지 : {1} => {2}") // 파라미터 테스트
+       void givenCurrentPageNumberAndTotalPages_whenCalculating_thenReturnsPaginationBarNumbers(int currentPageNumber, int totalPages, List<Integer> expected) {
+           // Given
+
+           // When
+           List<Integer> actual = sut.getPaginationBarNumbers(currentPageNumber, totalPages);
+
+           // Then
+           assertThat(actual).isEqualTo(expected);
+       }
+
+       // @MethodSource를 클릭하여 생성
+       static Stream<Arguments> givenCurrentPageNumberAndTotalPages_whenCalculating_thenReturnsPaginationBarNumbers() {
+
+           return Stream.of(
+                   // arguments = Arguments.arguments
+                   arguments(0, 13, List.of(0,1,2,3,4)), // pagenumber, page의 index는 0부터 시작됨
+                   arguments(1, 13, List.of(0,1,2,3,4)),
+                   arguments(2, 13, List.of(0,1,2,3,4)),
+                   arguments(3, 13, List.of(1,2,3,4,5)),
+                   arguments(4, 13, List.of(2,3,4,5,6)),
+                   arguments(5, 13, List.of(3,4,5,6,7)),
+                   arguments(6, 13, List.of(4,5,6,7,8)),
+                   arguments(10, 13, List.of(8,9,10,11,12)),
+                   arguments(11, 13, List.of(9,10,11,12)),
+                   arguments(12, 13, List.of(10,11,12)) // 13페이지까지이므로 index 기준은 12가 끝
+                   );
+       }
+
+       @DisplayName("현재 설정되어 있는 페이지네이션 바의 길이를 알려줌")
+       @Test
+       void givenNothing_whenCalling_thenReturnsCurrentBarLength() {
+           // Given
+
+           // When
+           int barLength = sut.currentBarLength();
+
+           // Then
+           assertThat(barLength).isEqualTo(5); // 상수 처리한 바 길이 5를 명시적으로 알려주기 위해 해당 테스트 작성
+
+       }
+
+}


### PR DESCRIPTION
에이전트 관리 페이지의 기능을 구현한다.
* [x] 주요 기능 테스트
  * [x] 정렬 기능 (이름순 / 생성일자 순)
  * [x] 페이지네이션 기능
  * [x] 에이전트 리스트 조회
  * [x] ~~에이전트 수정 - 에이전트 그룹 소속 변경~~
  * [x] 에이전트 삭제
  * [x] 에이전트 상세 정보 조회 (이름, 프로필, 매핑된 광고주)
  * [x] 에이전트 상세 정보 - 매핑 광고주 조회 (광고주 캠페인 관리 페이지로 리다이렉션)
* [x] 주요 기능 구현
  * [x] 정렬 기능 (이름순 / 생성일자 순)
  * [x] 페이지네이션 기능
  * [x] 에이전트 리스트 조회
  * [x] ~~에이전트 수정 - 에이전트 그룹 소속 변경~~
  * [x] 에이전트 삭제
  * [x] 에이전트 상세 정보 조회 (이름, 프로필, 매핑된 광고주)
  * [x] 에이전트 상세 정보 - 매핑 광고주 조회 (광고주 캠페인 관리 페이지로 리다이렉션)
* [x] 디자인 적용
  * [x] 에이전트 관리 페이지
  * [x] 에이전트 상세 페이지

다만 삭제 기능에서 조건부 관련 문제가 있는듯 하여 추후 수정하기로 하였음
This closes #33 