### PR TITLE
에이전트 그룹 관리 기능 구현 + 뷰 적용

### DIFF
--- a/src/main/java/com/agencyplatformclonecoding/controller/AgentController.java
+++ b/src/main/java/com/agencyplatformclonecoding/controller/AgentController.java
@@ -31,25 +31,25 @@ public class AgentController {
                 @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
                 ModelMap map
     	) {
-    		Page<AgentResponse> agents = agentService.searchAgents(searchType, searchValue, pageable)
+        Page<AgentResponse> agents = agentService.searchAgents(searchType, searchValue, pageable)
     				.map(AgentResponse::from);
-    		List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), agents.getTotalPages());
-            map.addAttribute("agents", agents);
-    		map.addAttribute("paginationBarNumbers", barNumbers);
-    		map.addAttribute("searchTypes", SearchType.values());
+        List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), agents.getTotalPages());
+        map.addAttribute("agents", agents);
+        map.addAttribute("paginationBarNumbers", barNumbers);
+        map.addAttribute("searchTypes", SearchType.values());
 
         return "agents/index";
     }
 
     @GetMapping("/{agentId}")
     public String agent(@PathVariable String agentId, ModelMap map) {
-    		AgentWithClientsResponse agent = AgentWithClientsResponse.from(agentService.getAgentWithClients(agentId));
+        AgentWithClientsResponse agent = AgentWithClientsResponse.from(agentService.getAgentWithClients(agentId));
 
-            map.addAttribute("agent", agent);
-            map.addAttribute("clients", agent.clientUserResponses());
-    		map.addAttribute("totalCount", agentService.getAgentCount());
+        map.addAttribute("agent", agent);
+        map.addAttribute("clients", agent.clientUserResponses());
+        map.addAttribute("totalCount", agentService.getAgentCount());
 
-         return "agents/detail";
+        return "agents/detail";
     }
     @GetMapping("/{agentId}/{clientId}")
     public String mappingClient(@PathVariable String agentId, String clientId) {

--- a/src/main/java/com/agencyplatformclonecoding/domain/constrant/FormStatus.java
+++ b/src/main/java/com/agencyplatformclonecoding/domain/constrant/FormStatus.java
@@ -1,0 +1,18 @@
+package com.agencyplatformclonecoding.domain.constrant;
+
+import lombok.Getter;
+
+public enum FormStatus {
+    CREATE("저장", false),
+    UPDATE("수정", true);
+
+    @Getter
+    private final String description;
+    @Getter private final Boolean update;
+
+    FormStatus(String description, Boolean update) {
+        this.description = description;
+        this.update = update;
+    }
+
+}

--- a/src/main/java/com/agencyplatformclonecoding/dto/request/AgentGroupRequest.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/request/AgentGroupRequest.java
@@ -1,0 +1,21 @@
+package com.agencyplatformclonecoding.dto.request;
+
+import com.agencyplatformclonecoding.dto.AgencyDto;
+import com.agencyplatformclonecoding.dto.AgentGroupDto;
+
+public record AgentGroupRequest(
+        String name
+) {
+
+    public static AgentGroupRequest of(String name) {
+        return new AgentGroupRequest(name);
+    }
+
+    public AgentGroupDto toDto(AgencyDto agencyDto) {
+        return AgentGroupDto.of(
+                agencyDto,
+                name
+        );
+    }
+
+}

--- a/src/main/java/com/agencyplatformclonecoding/dto/response/AgentGroupResponse.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/response/AgentGroupResponse.java
@@ -1,0 +1,27 @@
+package com.agencyplatformclonecoding.dto.response;
+
+import com.agencyplatformclonecoding.dto.AgentDto;
+import com.agencyplatformclonecoding.dto.AgentGroupDto;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+public record AgentGroupResponse (
+        String id,
+        LocalDateTime createdAt,
+        String name
+) implements Serializable {
+
+    public static AgentGroupResponse of(String id, LocalDateTime createdAt, String name) {
+        return new AgentGroupResponse(id, createdAt, name);
+    }
+
+    public static AgentGroupResponse from(AgentGroupDto dto) {
+        return new AgentGroupResponse(
+                dto.id(),
+                dto.createdAt(),
+                dto.name()
+        );
+    }
+}
+

--- a/src/main/java/com/agencyplatformclonecoding/dto/response/AgentGroupWithAgentsResponse.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/response/AgentGroupWithAgentsResponse.java
@@ -1,0 +1,35 @@
+package com.agencyplatformclonecoding.dto.response;
+
+import com.agencyplatformclonecoding.dto.AgentGroupWithAgentsDto;
+import com.agencyplatformclonecoding.dto.AgentWithClientsDto;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record AgentGroupWithAgentsResponse(
+        String id,
+        LocalDateTime createdAt,
+        String name,
+        Set<AgentResponse> agentResponses
+) implements Serializable {
+
+    public static AgentGroupWithAgentsResponse of (String Id, LocalDateTime createdAt, String name, Set<AgentResponse> agentResponses) {
+        return new AgentGroupWithAgentsResponse(Id, createdAt, name, agentResponses);
+    }
+
+    public static AgentGroupWithAgentsResponse from(AgentGroupWithAgentsDto dto) {
+
+        return new AgentGroupWithAgentsResponse(
+                dto.id(),
+                dto.createdAt(),
+                dto.name(),
+                dto.agentDtos().stream()
+                        .map(AgentResponse::from)
+                        .collect(Collectors.toCollection(LinkedHashSet::new))
+        );
+    }
+
+}

--- a/src/main/resources/templates/agentgroups/detail.html
+++ b/src/main/resources/templates/agentgroups/detail.html
@@ -1,10 +1,90 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
   <meta charset="UTF-8">
-  <title>Title</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="">
+  <meta name="author" content="mrcocoball">
+  <title>에이전트 그룹 상세 페이지</title>
+
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+  <link href="/css/search-bar.css" rel="stylesheet">
+  <link href="/css/articles/table-header.css" rel="stylesheet">
 </head>
+
 <body>
 
+  <header id="header">
+    헤더 삽입부
+    <hr>
+  </header>
+
+  <main class="d-flex flex-nowrap">
+    <div class="d-flex flex-column flex-shrink-0 p-3 text-bg-dark" style="width: 280px;, height: 100%;">
+      <a href="/" class="d-flex align-items-center mb-3 mb-md-0 me-md-auto text-white text-decoration-none">
+        <svg class="bi pe-none me-2" width="40" height="32"><use xlink:href="#bootstrap"/></svg>
+        <span class="fs-4"></span>
+      </a>
+      <ul class="nav nav-pills flex-column mb-auto">
+        <li class="nav-item">
+          <a href="#" class="nav-link text-white">
+            <svg class="bi pe-none me-2" width="16" height="16"><use xlink:href="#home"/></svg>
+            에이전트 관리
+          </a>
+        </li>
+        <li>
+          <a href="#" class="nav-link active" aria-current="page">
+            <svg class="bi pe-none me-2" width="16" height="16"><use xlink:href="#speedometer2"/></svg>
+            에이전트 그룹 관리
+          </a>
+        </li>
+        <li>
+          <a href="#" class="nav-link text-white">
+            <svg class="bi pe-none me-2" width="16" height="16"><use xlink:href="#table"/></svg>
+            광고주 관리
+          </a>
+        </li>
+        <li>
+          <a href="#" class="nav-link text-white">
+            <svg class="bi pe-none me-2" width="16" height="16"><use xlink:href="#grid"/></svg>
+            광고 관리
+          </a>
+        </li>
+        <li>
+          <a href="#" class="nav-link text-white">
+            <svg class="bi pe-none me-2" width="16" height="16"><use xlink:href="#people-circle"/></svg>
+            대시보드
+          </a>
+        </li>
+    </div>
+
+   <div class="container">
+   <h1> 에이전트 그룹 정보 </h1>
+    <div class="row">
+      <table class="table" id="agent-table">
+        <thead>
+        <tr>
+          <th class="agent-id col-2"><a>ID</a></th>
+          <th class="nickname col-2"><a>이름</a></th>
+          <th class="agent-info"></th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <td class="agent-id"><a>agent1</a></td>
+          <td class="nickname">김코코볼</td>
+          <th class="button"><a class="btn btn-primary" role="button" id="agent-info">에이전트 정보</a></th>
+        </tr>
+        <tr>
+          <td>agent2</td>
+          <td>김지오</td>
+          <th class="button"><a class="btn btn-primary" role="button" id="agent-info">에이전트 정보</a></th>
+        </tr>
+      </tbody>
+    </table>
+    </div>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-A3rJD856KowSb7dwlZdYEkO39Gagi7vIsF0jrRAoQmDKKtQBHUuLZ9AsSv4jD4Xa" crossorigin="anonymous"></script>
+
 </body>
-</html>

--- a/src/main/resources/templates/agentgroups/detail.th.xml
+++ b/src/main/resources/templates/agentgroups/detail.th.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<thlogic>
+  <attr sel="#header" th:replace="header :: header" />
+  <attr sel="#footer" th:replace="footer :: footer" />
+
+    <attr sel="#agent-table">
+      <attr sel="tbody" th:remove="all-but-first">
+        <attr sel="tr[0]" th:each="agent : ${agents}">
+          <attr sel="td.agent-id" th:text="${agent.userId}" />
+          <attr sel="td.nickname" th:text="${agent.nickname}" />
+          <attr sel="#agent-info" th:href="@{'/agents/' + ${agent.userId}}" />
+        </attr>
+      </attr>
+    </attr>
+  </attr>

--- a/src/main/resources/templates/agentgroups/form.html
+++ b/src/main/resources/templates/agentgroups/form.html
@@ -1,10 +1,51 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
   <meta charset="UTF-8">
-  <title>Title</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="">
+  <meta name="author" content="mrcocoball">
+  <title>에이전트 그룹 생성 페이지</title>
+
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+  <link href="/css/search-bar.css" rel="stylesheet">
+  <link href="/css/articles/table-header.css" rel="stylesheet">
 </head>
+
 <body>
 
+  <header id="header">
+    헤더 삽입부
+    <hr>
+  </header>
+
+  <div class="container">
+    <header id="agentgroup-form-header" class="py-5 text-center">
+      <h1>에이전트 그룹 관리</h1>
+    </header>
+
+    <form id="agentgroup-form">
+      <div class="row mb-3 justify-content-md-center">
+        <label for="id" class="col-sm-2 col-lg-1 col-form-label text-sm-end">그룹 ID</label>
+        <div class="col-sm-8 col-lg-9">
+          <input type="text" class="form-control" id="id" name="id" required>
+        </div>
+      </div>
+      <div class="row mb-3 justify-content-md-center">
+        <label for="name" class="col-sm-2 col-lg-1 col-form-label text-sm-end">그룹명</label>
+        <div class="col-sm-8 col-lg-9">
+          <input type="text" class="form-control" id="name" name="name" required>
+        </div>
+      </div>
+      <div class="row mb-5 justify-content-md-center">
+        <div class="col-sm-10 d-grid gap-2 d-sm-flex justify-content-sm-end">
+          <button type="submit" class="btn btn-primary" id="submit-button">저장</button>
+          <button type="button" class="btn btn-secondary" id="cancel-button">취소</button>
+        </div>
+      </div>
+    </form>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-A3rJD856KowSb7dwlZdYEkO39Gagi7vIsF0jrRAoQmDKKtQBHUuLZ9AsSv4jD4Xa" crossorigin="anonymous"></script>
+
 </body>
-</html>

--- a/src/main/resources/templates/agentgroups/form.th.xml
+++ b/src/main/resources/templates/agentgroups/form.th.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<thlogic>
+  <attr sel="#header" th:replace="header :: header" />
+  <attr sel="#footer" th:replace="footer :: footer" />
+
+  <attr sel="#agentgroup-form-header/h1" th:text="${formStatus} ? '에이전트 그룹 ' + ${formStatus.description} : _" />
+
+  <attr sel="#agentgroup-form" th:action="${formStatus?.update} ? '/agentGroups/' + ${agentGroup.id} + '/form' : '/agentGroups/form'" th:method="post">
+    <attr sel="#id" th:value="${agentGroup?.id} ?: _" />
+    <attr sel="#name" th:text="${agentGroup?.name} ?: _" />
+    <attr sel="#submit-button" th:text="${formStatus?.description} ?: _" />
+    <attr sel="#cancel-button" th:onclick="'history.back()'" />
+  </attr>
+</thlogic>

--- a/src/main/resources/templates/agentgroups/index.html
+++ b/src/main/resources/templates/agentgroups/index.html
@@ -96,56 +96,56 @@
 
     <div class="row">
       <div class="d-grid gap-2 d-md-flex justify-content-md">
-        <a class="btn btn-primary me-md-2" role="button" id="write-article">에이전트 그룹 생성</a>
+        <a class="btn btn-primary me-md-2" role="button" id="create-agentgroup">에이전트 그룹 생성</a>
       </div>
     </div>
 
     <div class="row">
-      <table class="table" id="client-table">
+      <table class="table" id="agentgroup-table">
         <thead>
         <tr>
-          <th class="user-id col-2"><a>ID</a></th>
-          <th class="nickname col-2"><a>그룹명</a></th>
-          <th class="created-at col"><a>그룹 생성일</a></th>
-          <th class="profile col-2"><a>소속 에이전트 확인</a></th>
+          <th class="id col-2"><a>ID</a></th>
+          <th class="name col-2"><a>그룹명</a></th>
+          <th class="agents-list col-2"><a>소속 에이전트 확인</a></th>
+          <th class="button"><a></a></th>
           <th class="button"><a></a></th>
         </tr>
         </thead>
         <tbody>
         <tr>
-          <td class="user-id"><a>team01</a></td>
-          <td class="nickname">마케팅 1팀</td>
-          <td class="clients"><time>2022-08-18</time></td>
-          <td class="profile">소속 에이전트 확인</td>
-          <td class="button"><a class="btn btn-danger me-md-2" role="button" id="agent-delete">삭제</a></td>
+          <td class="id"><a>team01</a></td>
+          <td class="name">마케팅 1팀</td>
+          <td class="button"><a class="btn btn-primary me-md-2" role="button" id="agents-list">소속 에이전트 확인</a></td>
+          <td class="button"><a class="btn btn-secondary" role="button" id="update-agentgroup">이름 변경</a></td>
+          <td class="button"><a class="btn btn-danger me-md-2" role="button" id="delete-agentgroup">삭제</a></td>
         </tr>
         <tr>
           <td>team02</td>
           <td>마케팅 2팀</td>
-          <td>2022-08-19</td>
-          <td class="profile">소속 에이전트 확인</td>
-          <td class="button"><a class="btn btn-danger me-md-2" role="button" id="agent-delete">삭제</a></td>
+          <td class="button"><a class="btn btn-primary me-md-2" role="button" id="agents-list">소속 에이전트 확인</a></td>
+          <td class="button"><a class="btn btn-secondary" role="button" id="update-agentgroup">이름 변경</a></td>
+          <td class="button"><a class="btn btn-danger me-md-2" role="button" id="delete-agentgroup">삭제</a></td>
         </tr>
         <tr>
           <td>team03</td>
           <td>마케팅 3팀</td>
-          <td>2022-08-20</td>
-          <td class="profile">소속 에이전트 확인</td>
-          <td class="button"><a class="btn btn-danger me-md-2" role="button" id="agent-delete">삭제</a></td>
+          <td class="button"><a class="btn btn-primary me-md-2" role="button" id="agents-list">소속 에이전트 확인</a></td>
+          <td class="button"><a class="btn btn-secondary" role="button" id="update-agentgroup">이름 변경</a></td>
+          <td class="button"><a class="btn btn-danger me-md-2" role="button" id="delete-agentgroup">삭제</a></td>
         </tr>
         <tr>
           <td>team04</td>
           <td>마케팅 5팀</td>
-          <td>2022-08-20</td>
-          <td class="profile">소속 에이전트 확인</td>
-          <td class="button"><a class="btn btn-danger me-md-2" role="button" id="agent-delete">삭제</a></td>
+          <td class="button"><a class="btn btn-primary me-md-2" role="button" id="agents-list">소속 에이전트 확인</a></td>
+          <td class="button"><a class="btn btn-secondary" role="button" id="update-agentgroup">이름 변경</a></td>
+          <td class="button"><a class="btn btn-danger me-md-2" role="button" id="delete-agentgroup">삭제</a></td>
         </tr>
         <tr>
           <td>team05</td>
           <td>마케팅 본부</td>
-          <td>2022-08-20</td>
-          <td class="profile">소속 에이전트 확인</td>
-          <td class="button"><a class="btn btn-danger me-md-2" role="button" id="agent-delete">삭제</a></td>
+          <td class="button"><a class="btn btn-primary me-md-2" role="button" id="agents-list">소속 에이전트 확인</a></td>
+          <td class="button"><a class="btn btn-secondary" role="button" id="update-agentgroup">이름 변경</a></td>
+          <td class="button"><a class="btn btn-danger me-md-2" role="button" id="delete-agentgroup">삭제</a></td>
         </tr>
       </tbody>
     </table>

--- a/src/main/resources/templates/agentgroups/index.th.xml
+++ b/src/main/resources/templates/agentgroups/index.th.xml
@@ -1,4 +1,67 @@
 <?xml version="1.0"?>
 <thlogic>
   <attr sel="#header" th:replace="header :: header" />
+  <attr sel="#footer" th:replace="footer :: footer" />
+
+  <attr sel="main" th:object="${agentGroups}">
+    <attr sel="#search-form" th:action="@{/agentGroups}" th:method="get" />
+    <attr sel="#search-type" th:remove="all-but-first">
+      <attr sel="option[0]"
+            th:each="searchType : ${searchTypes}"
+            th:value="${searchType.name}"
+            th:text="${searchType.description}"
+            th:selected="${param.searchType != null && (param.searchType.toString == searchType.name)}"
+      />
+    </attr>
+    <attr sel="#search-value" th:value="${param.searchValue}" />
+
+    <attr sel="#create-agentgroup" th:href="@{/agentGroups/form}" />
+
+    <attr sel="#agentgroup-table">
+      <attr sel="thead/tr">
+        <attr sel="th.id/a" th:text="'그룹 ID'" th:href="@{/agentGroups(
+            page=${agentGroups.number},
+            sort='id' + (*{sort.getOrderFor('id')} != null ? (*{sort.getOrderFor('id').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${param.searchType},
+            searchValue=${param.searchValue}
+        )}"/>
+        <attr sel="th.name/a" th:text="'그룹명'" th:href="@{/agentGroups(
+            page=${agentGroups.number},
+            sort='name' + (*{sort.getOrderFor('name')} != null ? (*{sort.getOrderFor('name').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${param.searchType},
+            searchValue=${param.searchValue}
+        )}"/>
+      </attr>
+
+      <attr sel="tbody" th:remove="all-but-first">
+        <attr sel="tr[0]" th:each="agentGroup : ${agentGroups}">
+          <attr sel="td.id" th:text="${agentGroup.id}" th:href="@{'/agentGroups/' + ${agentGroup.id}}" />
+          <attr sel="td.name" th:text="${agentGroup.name}" />
+          <attr sel="#agents-list" th:href="@{'/agentGroups/' + ${agentGroup.id}}" />
+          <attr sel="#update-agentgroup" th:href="'/agentGroups/' + ${agentGroup.id} + '/form'" />
+          <attr sel="#delete-agentgroup" th:action="'/agentGroups/' + ${agentGroup.id} + '/delete'" th:method="post" />
+        </attr>
+      </attr>
+    </attr>
+
+    <attr sel="#pagination">
+      <attr sel="li[0]/a"
+            th:text="'previous'"
+            th:href="@{/agentGroups(page=${agentGroups.number - 1}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
+            th:class="'page-link' + (${agentGroups.number} <= 0 ? ' disabled' : '')"
+      />
+      <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
+        <attr sel="a"
+              th:text="${pageNumber + 1}"
+              th:href="@{/agentGroups(page=${pageNumber}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
+              th:class="'page-link' + (${pageNumber} == ${agentGroups.number} ? ' disabled' : '')"
+        />
+      </attr>
+      <attr sel="li[2]/a"
+            th:text="'next'"
+            th:href="@{/agentGroups(page=${agentGroups.number + 1}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
+            th:class="'page-link' + (${agentGroups.number} >= ${agentGroups.totalPages - 1} ? ' disabled' : '')"
+      />
+    </attr>
+  </attr>
 </thlogic>

--- a/src/main/resources/templates/agents/index.th.xml
+++ b/src/main/resources/templates/agents/index.th.xml
@@ -37,7 +37,7 @@
           <attr sel="td.agent-group" th:text="${agent.agentGroupName}" />
           <attr sel="td.created-at/time" th:datetime="${agent.createdAt}" th:text="${#temporals.format(agent.createdAt, 'yyyy-MM-dd')}" />
           <attr sel="#agent-info" th:href="@{'/agents/' + ${agent.userId}}" />
-          <attr sel="#agent-delete" th:action="@{'/agents/' + ${agent.userId}} + '/delete'" th:method="post" />
+          <attr sel="#agent-delete" th:action="'/agents/' + ${agent.userId} + '/delete'" th:method="post" />
         </attr>
       </attr>
     </attr>

--- a/src/test/java/com/agencyplatformclonecoding/controller/AgentGroupControllerTest.java
+++ b/src/test/java/com/agencyplatformclonecoding/controller/AgentGroupControllerTest.java
@@ -1,9 +1,18 @@
 package com.agencyplatformclonecoding.controller;
 
 import com.agencyplatformclonecoding.config.SecurityConfig;
+import com.agencyplatformclonecoding.domain.constrant.FormStatus;
+import com.agencyplatformclonecoding.domain.constrant.SearchType;
+import com.agencyplatformclonecoding.dto.AgencyDto;
+import com.agencyplatformclonecoding.dto.AgentGroupDto;
+import com.agencyplatformclonecoding.dto.AgentGroupWithAgentsDto;
+import com.agencyplatformclonecoding.dto.AgentWithClientsDto;
+import com.agencyplatformclonecoding.dto.request.AgentGroupRequest;
+import com.agencyplatformclonecoding.dto.response.AgentGroupResponse;
 import com.agencyplatformclonecoding.service.AgentGroupService;
 import com.agencyplatformclonecoding.service.AgentService;
 import com.agencyplatformclonecoding.service.PaginationService;
+import com.agencyplatformclonecoding.util.FormDataEncoder;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,21 +20,34 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 
 @DisplayName("VIEW 컨트롤러 - 에이전트 그룹 관리")
-@Import(SecurityConfig.class)
+@Import({SecurityConfig.class, FormDataEncoder.class})
 @WebMvcTest(AgentGroupController.class)
 class AgentGroupControllerTest {
 
     private final MockMvc mvc;
+    private final FormDataEncoder formDataEncoder;
 
     @MockBean
     private AgentGroupService agentGroupService;
@@ -34,31 +56,65 @@ class AgentGroupControllerTest {
     private PaginationService paginationService;
 
     public AgentGroupControllerTest(
-            @Autowired MockMvc mvc
+            @Autowired MockMvc mvc,
+            @Autowired FormDataEncoder formDataEncoder
     ) {
         this.mvc = mvc;
+        this.formDataEncoder = formDataEncoder;
     }
 
     @DisplayName("[VIEW][GET] 에이전트 그룹 리스트 - 정상 호출")
     @Test
     public void givenNothing_whenRequestingAgentGroupsView_thenReturnsAgentGroupsView() throws Exception {
         // Given
+		given(agentGroupService.searchAgentGroups(eq(null), eq(null), any(Pageable.class))).willReturn(Page.empty());
+		given(paginationService.getPaginationBarNumbers(anyInt(), anyInt())).willReturn(List.of(0,1,2,3,4));
 
         // When & Then
         mvc.perform(get("/agentGroups"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("agentgroups/index"))
-                .andExpect(model().attributeExists("agentGroups"));
+				.andExpect(model().attributeExists("agentGroups"))
+				.andExpect(model().attributeExists("paginationBarNumbers"));
+		then(agentGroupService).should().searchAgentGroups(eq(null), eq(null), any(Pageable.class));
     }
+
+    @DisplayName("[VIEW][GET] 에이전트 그룹 리스트 - 검색어와 함께 호출")
+    @Test
+    public void givenSearchKeyword_whenSearchingAgentGroupsView_thenReturnsAgentGroupsView() throws Exception {
+        // Given
+   		SearchType searchType = SearchType.NICKNAME;
+   		String searchValue = "name";
+   		given(agentGroupService.searchAgentGroups(eq(searchType), eq(searchValue), any(Pageable.class))).willReturn(Page.empty());
+        given(paginationService.getPaginationBarNumbers(anyInt(), anyInt())).willReturn(List.of(0,1,2,3,4));
+
+        // When & Then
+        mvc.perform(
+                get("/agentGroups")
+                        .queryParam("searchType", searchType.name())
+                        .queryParam("searchValue", searchValue)
+   				)
+                   .andExpect(status().isOk())
+                   .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                   .andExpect(view().name("agentgroups/index"))
+                   .andExpect(model().attributeExists("agentGroups"))
+   				.andExpect(model().attributeExists("searchTypes"));
+   		then(agentGroupService).should().searchAgentGroups(eq(searchType), eq(searchValue), any(Pageable.class));
+   		then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
+       }
 
     @DisplayName("[VIEW][GET] 에이전트 그룹 상세 정보 - 정상 호출")
     @Test
     public void givenNothing_whenRequestingAgentGroupDetailView_thenReturnsAgentGroupDetailView() throws Exception {
         // Given
+		String agentGroupId = "t-group";
+		Long totalCount = 1L;
+		given(agentGroupService.getAgentGroupWithAgents(agentGroupId)).willReturn(createAgentGroupWithAgentsDto());
+		given(agentGroupService.getAgentGroupCount()).willReturn(totalCount);
 
         // When & Then
-        mvc.perform(get("/agentGroups/mkt1"))
+        mvc.perform(get("/agentGroups/" + agentGroupId))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("agentgroups/detail"))
@@ -78,5 +134,143 @@ class AgentGroupControllerTest {
                 .andExpect(forwardedUrl("/agents/{agentId}"))
                 .andDo(MockMvcResultHandlers.print());
     }
+
+    //0829 추가
+    @DisplayName("[VIEW][GET] 에이전트 그룹 페이지 - 페이징, 정렬 기능")
+    @Test
+    void givenPagingAndSortingParams_whenSearchingAgentsPage_thenReturnsAgentsView() throws Exception {
+        // Given
+        String sortName = "title";
+        String direction = "desc";
+        int pageNumber = 0;
+        int pageSize = 5;
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Order.desc(sortName)));
+        List<Integer> barNumbers = List.of(1, 2, 3, 4, 5);
+        given(agentGroupService.searchAgentGroups(null, null, pageable)).willReturn(Page.empty());
+        given(paginationService.getPaginationBarNumbers(pageable.getPageNumber(), Page.empty().getTotalPages())).willReturn(barNumbers);
+
+        // When & Then
+        mvc.perform(
+                get("/agentGroups")
+                        .queryParam("page", String.valueOf(pageNumber))
+                        .queryParam("size", String.valueOf(pageSize))
+                        .queryParam("sort", sortName + "," + direction)
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("agentgroups/index"))
+                .andExpect(model().attributeExists("agentGroups"))
+                .andExpect(model().attribute("paginationBarNumbers", barNumbers));
+        then(agentGroupService).should().searchAgentGroups(null, null, pageable);
+        then(paginationService).should().getPaginationBarNumbers(pageable.getPageNumber(), Page.empty().getTotalPages());
+    }
+
+   	// 이하 0829 추가
+   	@DisplayName("[VIEW][GET] 새 에이전트 그룹 생성 페이지")
+    @Test
+    void givenNothing_whenRequesting_thenReturnsNewAgentGroupPage() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/agentGroups/form"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("agentgroups/form"))
+                .andExpect(model().attribute("formStatus", FormStatus.CREATE));
+    }
+
+   	@DisplayName("[VIEW][POST] 새 에이전트 그룹 생성 - 정상 호출")
+    @Test
+    void givenNewAgentGroupInfo_whenRequesting_thenSavesNewAgentGroup() throws Exception {
+        // Given
+        AgentGroupRequest agentGroupRequest = AgentGroupRequest.of("테스트용 그룹");
+        willDoNothing().given(agentGroupService).saveAgentGroup(any(AgentGroupDto.class));
+
+        // When & Then
+        mvc.perform(
+                post("/agentGroups/form") // post : MockMvcRequestBuilders.post
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .content(formDataEncoder.encode(agentGroupRequest))
+                        .with(csrf()) // csrf : SecurityMockMvcRequestPostProcessors.csrf
+                )
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/agentGroups"))
+                .andExpect(redirectedUrl("/agentGroups"));
+        then(agentGroupService).should().saveAgentGroup(any(AgentGroupDto.class));
+    }
+
+   	@DisplayName("[VIEW][GET] 에이전트 그룹 수정 페이지")
+    @Test
+    void givenNothing_whenRequesting_thenReturnsUpdatedAgentGroupPage() throws Exception {
+        // Given
+        String agentGroupId = "t-group";
+        AgentGroupDto dto = createAgentGroupDto();
+        given(agentGroupService.getAgentGroup(agentGroupId)).willReturn(dto);
+
+        // When & Then
+        mvc.perform(get("/agentGroups/" + agentGroupId + "/form"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("agentgroups/form"))
+                .andExpect(model().attribute("agentGroup", AgentGroupResponse.from(dto)))
+                .andExpect(model().attribute("formStatus", FormStatus.UPDATE));
+        then(agentGroupService).should().getAgentGroup(agentGroupId);
+    }
+
+   	@DisplayName("[VIEW][POST] 에이전트 그룹 수정 - 정상 호출")
+    @Test
+    void givenUpdatedAgentGroupInfo_whenRequesting_thenUpdatesNewAgentGroup() throws Exception {
+        // Given
+        String agentGroupId = "t-group";
+        AgentGroupRequest agentGroupRequest = AgentGroupRequest.of("새 그룹 이름");
+        willDoNothing().given(agentGroupService).updateAgentGroup(eq(agentGroupId), any(AgentGroupDto.class));
+
+        // When & Then
+        mvc.perform(
+                post("/agentGroups/" + agentGroupId + "/form")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .content(formDataEncoder.encode(agentGroupRequest))
+                        .with(csrf())
+                )
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/agentGroups/" + agentGroupId))
+                .andExpect(redirectedUrl("/agentGroups/" + agentGroupId));
+        then(agentGroupService).should().updateAgentGroup(eq(agentGroupId), any(AgentGroupDto.class));
+    }
+
+
+    // fixture
+
+       private AgencyDto createAgencyDto() {
+           return AgencyDto.of(
+                   "t-agency",
+                   "테스트용"
+           );
+       }
+
+       private AgentGroupDto createAgentGroupDto() {
+           return AgentGroupDto.of(
+                   createAgencyDto(),
+                   "t-group",
+                   "테스트용",
+                   LocalDateTime.now(),
+                   "테스트",
+                   LocalDateTime.now(),
+                   "테스트"
+           );
+       }
+
+   	    private AgentGroupWithAgentsDto createAgentGroupWithAgentsDto() {
+           return AgentGroupWithAgentsDto.of(
+                   createAgencyDto(),
+                   Set.of(),
+                   "t-client",
+                   "김테스트",
+                   LocalDateTime.now(),
+                   "김테스트",
+                   LocalDateTime.now(),
+                   "테스트"
+           );
+       }
 
 }

--- a/src/test/java/com/agencyplatformclonecoding/util/FormDataEncoder.java
+++ b/src/test/java/com/agencyplatformclonecoding/util/FormDataEncoder.java
@@ -1,0 +1,34 @@
+package com.agencyplatformclonecoding.util;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.Map;
+
+@TestComponent
+public class FormDataEncoder {
+
+    private final ObjectMapper mapper;
+
+    public FormDataEncoder(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+
+    public String encode(Object obj) {
+        Map<String, String> fieldMap = mapper.convertValue(obj, new TypeReference<>() {});
+        MultiValueMap<String, String> valueMap = new LinkedMultiValueMap<>();
+        valueMap.setAll(fieldMap);
+
+        return UriComponentsBuilder.newInstance()
+                .queryParams(valueMap)
+                .encode()
+                .build()
+                .getQuery();
+    }
+
+}


### PR DESCRIPTION
에이전트 그룹 관리 페이지의 기능을 구현한다.
* [x] 주요 기능 테스트
  * [x] 정렬 기능 (이름순 / 생성일자 순)
  * [x] 페이지네이션 기능
  * [x] 에이전트 그룹 리스트 조회
  * [x] 에이전트 그룹 생성
  * [x] 에이전트 그룹 수정 (이름)
  * [x] ~~에이전트 그룹 삭제~~
  * [x] 에이전트 그룹 상세 정보 조회 (이름, 프로필, 소속된 에이전트)
  * [x] 에이전트 그룹 상세 정보 - 소속된 에이전트 조회 (에이전트 관리 상세 페이지로 리다이렉션)
  * [x] 에이전트 그룹 상세 정보 - 에이전트 생성
  * [x] 에이전트 그룹 내 소속된 에이전트 수 카운트
* [x] 주요 기능 구현
  * [x] 정렬 기능 (이름순 / 생성일자 순)
  * [x] 페이지네이션 기능
  * [x] 에이전트 그룹 리스트 조회
  * [x] 에이전트 그룹 생성
  * [x] 에이전트 그룹 수정 (이름)
  * [x] ~~에이전트 그룹 삭제~~
  * [x] 에이전트 그룹 상세 정보 조회 (이름, 프로필, 소속된 에이전트)
  * [x] 에이전트 그룹 상세 정보 - 소속된 에이전트 조회 (에이전트 관리 상세 페이지로 리다이렉션)
  * [x] 에이전트 그룹 상세 정보 - 에이전트 생성
  * [x] 에이전트 그룹 내 소속된 에이전트 수 카운트
* [x] 디자인 적용
  * [x] form 뷰 관련 Bootstrap 확인
  * [x] 에이전트 그룹 관리 페이지
  * [x] 에이전트 그룹 상세 페이지
  * [x] 에이전트 그룹 수정 폼

다만 에이전트 그룹 id를 String으로 한 상태여서 생성 / 수정 시 에이전트 그룹 id를 수정, save할 시
IdentifierGenerationException 이 발생, id를 직접 식별자 할당해야하는 이슈가 발생하여
에이전트 그룹 id를 long 타입으로 바꾸고 자동 할당으로 바꿔야 할 것으로 보임.
일단 기능 먼저 구현하였고 전반적인 기능 추가가 이뤄지면 리팩토링 진행 예정.
https://hangjastar.tistory.com/241

This closes #34 