### PR TITLE
광고 관리 (광고주) 기능 구현 + 뷰 적용

### DIFF
--- a/src/main/java/com/agencyplatformclonecoding/dto/CampaignDto.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/CampaignDto.java
@@ -1,0 +1,48 @@
+package com.agencyplatformclonecoding.dto;
+
+import com.agencyplatformclonecoding.domain.Campaign;
+import com.agencyplatformclonecoding.domain.ClientUser;
+
+import java.time.LocalDateTime;
+
+public record CampaignDto(
+        ClientUserDto clientUserDto,
+        Long id,
+        String name,
+        Long budget,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+
+    public static CampaignDto of(ClientUserDto clientUserDto, String name, Long budget) {
+        return new CampaignDto(clientUserDto, null, name, budget, null, null, null, null);
+    }
+    public static CampaignDto of(ClientUserDto clientUserDto, Long id, String name, Long budget, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new CampaignDto(clientUserDto, id, name, budget, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    // Entity -> dto로 변환
+    public static CampaignDto from(Campaign entity) {
+        return new CampaignDto(
+				ClientUserDto.from(entity.getClientUser()),
+				entity.getId(),
+                entity.getName(),
+                entity.getBudget(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+    // dto -> Entity로 변환
+    public Campaign toEntity(ClientUser clientUser) {
+        return Campaign.of(
+                clientUser,
+				name,
+                budget
+        );
+    }
+}

--- a/src/main/java/com/agencyplatformclonecoding/dto/ClientUserWithCampaignsDto.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/ClientUserWithCampaignsDto.java
@@ -1,0 +1,46 @@
+package com.agencyplatformclonecoding.dto;
+
+import com.agencyplatformclonecoding.domain.ClientUser;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record ClientUserWithCampaignsDto(
+        AgencyDto agencyDto,
+        AgentDto agentDto,
+        String userId,
+        String userPassword,
+        String nickname,
+        String email,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy,
+		Set<CampaignDto> campaignDtos
+) {
+
+    public static ClientUserWithCampaignsDto of(AgencyDto agencyDto, AgentDto agentDto, String userId, String password, String nickname, String email, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy, Set<CampaignDto> campaignDtos) {
+        return new ClientUserWithCampaignsDto(agencyDto, agentDto, userId, password, nickname, email, createdAt, createdBy, modifiedAt, modifiedBy, campaignDtos);
+    }
+
+    // Entity -> dto로 변환
+    public static ClientUserWithCampaignsDto from(ClientUser entity) {
+        return new ClientUserWithCampaignsDto(
+                AgencyDto.from(entity.getAgency()),
+				AgentDto.from(entity.getAgent()),
+				entity.getUserId(),
+                entity.getUserPassword(),
+                entity.getNickname(),
+                entity.getEmail(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy(),
+				entity.getCampaigns().stream()
+								.map(CampaignDto::from)
+								.collect(Collectors.toCollection(LinkedHashSet::new))
+        );
+    }
+}

--- a/src/main/java/com/agencyplatformclonecoding/dto/response/CampaignResponse.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/response/CampaignResponse.java
@@ -1,0 +1,35 @@
+package com.agencyplatformclonecoding.dto.response;
+
+import com.agencyplatformclonecoding.dto.CampaignDto;
+import com.agencyplatformclonecoding.dto.ClientUserDto;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+public record CampaignResponse(
+        Long id,
+        LocalDateTime createdAt,
+        String name,
+        Long budget,
+        String clientUserName
+) implements Serializable {
+
+    public static CampaignResponse of (Long id, LocalDateTime createdAt, String name, Long budget, String clientUserName) {
+        return new CampaignResponse(id, createdAt, name, budget, clientUserName);
+    }
+
+    public static CampaignResponse from (CampaignDto dto) {
+        String clientUserName = dto.clientUserDto().nickname();
+        if (clientUserName == null || clientUserName.isBlank()) {
+            clientUserName = dto.clientUserDto().userId();
+        }
+
+        return new CampaignResponse(
+                dto.id(),
+                dto.createdAt(),
+                dto.name(),
+                dto.budget(),
+                clientUserName
+        );
+    }
+}

--- a/src/main/java/com/agencyplatformclonecoding/dto/response/ClientUserWithCampaignsResponse.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/response/ClientUserWithCampaignsResponse.java
@@ -1,0 +1,33 @@
+package com.agencyplatformclonecoding.dto.response;
+
+import com.agencyplatformclonecoding.dto.ClientUserWithCampaignsDto;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record ClientUserWithCampaignsResponse(
+        String userId,
+        LocalDateTime createdAt,
+        String nickname,
+        Set<CampaignResponse> campaignResponses
+) implements Serializable {
+
+    public static ClientUserWithCampaignsResponse of (String userId, LocalDateTime createdAt, String nickname, Set<CampaignResponse> campaignResponses) {
+        return new ClientUserWithCampaignsResponse(userId, createdAt, nickname, campaignResponses);
+    }
+
+    public static ClientUserWithCampaignsResponse from(ClientUserWithCampaignsDto dto) {
+        return new ClientUserWithCampaignsResponse(
+                dto.userId(),
+                dto.createdAt(),
+                dto.nickname(),
+                dto.campaignDtos().stream()
+                        .map(CampaignResponse::from)
+                        .collect(Collectors.toCollection(LinkedHashSet::new))
+        );
+    }
+
+}

--- a/src/main/java/com/agencyplatformclonecoding/service/ManageService.java
+++ b/src/main/java/com/agencyplatformclonecoding/service/ManageService.java
@@ -1,13 +1,20 @@
 package com.agencyplatformclonecoding.service;
 
+import com.agencyplatformclonecoding.domain.constrant.SearchType;
+import com.agencyplatformclonecoding.dto.ClientUserDto;
+import com.agencyplatformclonecoding.dto.ClientUserWithCampaignsDto;
 import com.agencyplatformclonecoding.repository.AgentRepository;
 import com.agencyplatformclonecoding.repository.CampaignRepository;
 import com.agencyplatformclonecoding.repository.ClientUserRepository;
 import com.agencyplatformclonecoding.repository.CreativeRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -15,9 +22,37 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class ManageService {
 
-    private final AgentRepository agentRepository;
     private final ClientUserRepository clientUserRepository;
-    private final CampaignRepository campaignRepository;
-    private final CreativeRepository creativeRepository;
+	private final CampaignRepository campaignRepository;
+	private final CreativeRepository creativeRepository;
 
+    @Transactional(readOnly = true)
+    public ClientUserDto getClientUser(String clientId) {
+        return clientUserRepository.findById(clientId)
+                .map(ClientUserDto::from)
+                .orElseThrow(() -> new EntityNotFoundException("광고주가 존재하지 않습니다 - clientId : " + clientId));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ClientUserDto> searchClientUsers(SearchType searchType, String searchKeyword, Pageable pageable) {
+        if (searchKeyword == null || searchKeyword.isBlank()) {
+            return clientUserRepository.findAll(pageable).map(ClientUserDto::from);
+        }
+
+        return switch(searchType) {
+            case ID -> clientUserRepository.findByUserIdContaining(searchKeyword, pageable).map(ClientUserDto::from);
+            case NICKNAME -> clientUserRepository.findByNicknameContaining(searchKeyword, pageable).map(ClientUserDto::from);
+        };
+    }
+
+    @Transactional(readOnly = true)
+    public ClientUserWithCampaignsDto getClientUserWithCampaigns(String clientId) {
+        return clientUserRepository.findById(clientId)
+                .map(ClientUserWithCampaignsDto::from)
+                .orElseThrow(() -> new EntityNotFoundException("광고주가 존재하지 않습니다 - clientId : " + clientId));
+    }
+
+    public long getClientUserCount() {
+        return clientUserRepository.count();
+    }
 }

--- a/src/main/resources/templates/clients/index.th.xml
+++ b/src/main/resources/templates/clients/index.th.xml
@@ -19,7 +19,7 @@
       <attr sel="thead/tr">
         <attr sel="th.user-id/a" th:text="'광고주 ID'" th:href="@{/clients(
             page=${clientUsers.number},
-            sort='user-id' + (*{sort.getOrderFor('user-id')} != null ? (*{sort.getOrderFor('user-id').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            sort='userId' + (*{sort.getOrderFor('userId')} != null ? (*{sort.getOrderFor('userId').direction.name} != 'DESC' ? ',desc' : '') : ''),
             searchType=${param.searchType},
             searchValue=${param.searchValue}
         )}"/>
@@ -37,7 +37,7 @@
           <attr sel="td.nickname" th:text="${clientUser.nickname}" />
 		  <attr sel="td.agent-name" th:text="${clientUser.agentName}" />
           <attr sel="#client-info" th:href="@{'/clients/' + ${clientUser.userId}}" />
-          <attr sel="#client-manage" th:href="@{'/manage/' + ${clientUser.userId}}" />
+          <attr sel="#client-manage" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'}" />
           <attr sel="#client-mapping" th:href="@{'/clients/' + ${clientUser.userId}}" />
         </attr>
       </attr>

--- a/src/main/resources/templates/manage/index.html
+++ b/src/main/resources/templates/manage/index.html
@@ -100,69 +100,69 @@
         <tr>
           <th class="user-id col-2"><a>광고주 ID</a></th>
           <th class="nickname col-2"><a>광고주명</a></th>
-          <th class="agent col-2"><a>담당 에이전트</a></th>
-          <th class="manage col-2"><a></a></th>
+          <th class="agent-name col-2"><a>담당 에이전트</a></th>
+          <th class="client-manage col-2"><a></a></th>
         </tr>
         </thead>
         <tbody>
         <tr>
           <td class="user-id"><a>client1</a></td>
           <td class="nickname">코코볼자동차</td>
-          <td class="agent">김코코볼</td>
+          <td class="agent-name">김코코볼</td>
           <td class="button"><a class="btn btn-primary" role="button" id="client-manage">광고 관리</a></td>
         </tr>
         <tr>
           <td class="user-id"><a>client2</a></td>
           <td class="nickname">코코볼전자</td>
-          <td class="agent">김코코볼</td>
+          <td class="agent-name">김코코볼</td>
           <td class="button"><a class="btn btn-primary" role="button" id="client-manage">광고 관리</a></td>
         </tr>
         <tr>
           <td class="user-id"><a>client3</a></td>
           <td class="nickname">코코볼물산</td>
-          <td class="agent">김지오</td>
+          <td class="agent-name">김지오</td>
           <td class="button"><a class="btn btn-primary" role="button" id="client-manage">광고 관리</a></td>
         </tr>
         <tr>
           <td class="user-id"><a>client4</a></td>
           <td class="nickname">코코볼식품</td>
-          <td class="agent">김지오</td>
+          <td class="agent-name">김지오</td>
           <td class="button"><a class="btn btn-primary" role="button" id="client-manage">광고 관리</a></td>
         </tr>
         <tr>
           <td class="user-id"><a>client5</a></td>
           <td class="nickname">코코볼생명보험</td>
-          <td class="agent">김지오</td>
+          <td class="agent-name">김지오</td>
           <td class="button"><a class="btn btn-primary" role="button" id="client-manage">광고 관리</a></td>
         </tr>
         <tr>
           <td class="user-id"><a>client6</a></td>
           <td class="nickname">코코볼뱅크</td>
-          <td class="agent">김호빵</td>
+          <td class="agent-name">김호빵</td>
           <td class="button"><a class="btn btn-primary" role="button" id="client-manage">광고 관리</a></td>
         </tr>
         <tr>
           <td class="user-id"><a>client7</a></td>
           <td class="nickname">코코볼의집</td>
-          <td class="agent">김호빵</td>
+          <td class="agent-name">김호빵</td>
           <td class="button"><a class="btn btn-primary" role="button" id="client-manage">광고 관리</a></td>
         </tr>
         <tr>
           <td class="user-id"><a>client8</a></td>
           <td class="nickname">코코볼리</td>
-          <td class="agent">김호떡</td>
+          <td class="agent-name">김호떡</td>
           <td class="button"><a class="btn btn-primary" role="button" id="client-manage">광고 관리</a></td>
         </tr>
         <tr>
           <td class="user-id"><a>client9</a></td>
           <td class="nickname">코코볼마켓</td>
-          <td class="agent">김호떡</td>
+          <td class="agent-name">김호떡</td>
           <td class="button"><a class="btn btn-primary" role="button" id="client-manage">광고 관리</a></td>
         </tr>
         <tr>
           <td class="user-id"><a>client10</a></td>
           <td class="nickname">코코볼의민족</td>
-          <td class="agent">김모찌</td>
+          <td class="agent-name">김모찌</td>
           <td class="button"><a class="btn btn-primary" role="button" id="client-manage">광고 관리</a></td>
         </tr>
       </tbody>

--- a/src/main/resources/templates/manage/index.th.xml
+++ b/src/main/resources/templates/manage/index.th.xml
@@ -1,4 +1,64 @@
 <?xml version="1.0"?>
 <thlogic>
   <attr sel="#header" th:replace="header :: header" />
+  <attr sel="#footer" th:replace="footer :: footer" />
+
+  <attr sel="main" th:object="${clientUsers}">
+    <attr sel="#search-form" th:action="@{/manage}" th:method="get" />
+    <attr sel="#search-type" th:remove="all-but-first">
+      <attr sel="option[0]"
+            th:each="searchType : ${searchTypes}"
+            th:value="${searchType.name}"
+            th:text="${searchType.description}"
+            th:selected="${param.searchType != null && (param.searchType.toString == searchType.name)}"
+      />
+    </attr>
+    <attr sel="#search-value" th:value="${param.searchValue}" />
+
+    <attr sel="#client-table">
+      <attr sel="thead/tr">
+        <attr sel="th.user-id/a" th:text="'광고주 ID'" th:href="@{/manage(
+            page=${clientUsers.number},
+            sort='userId' + (*{sort.getOrderFor('userId')} != null ? (*{sort.getOrderFor('userId').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${param.searchType},
+            searchValue=${param.searchValue}
+        )}"/>
+        <attr sel="th.nickname/a" th:text="'광고주명'" th:href="@{/manage(
+            page=${clientUsers.number},
+            sort='nickname' + (*{sort.getOrderFor('nickname')} != null ? (*{sort.getOrderFor('nickname').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${param.searchType},
+            searchValue=${param.searchValue}
+        )}"/>
+      </attr>
+
+      <attr sel="tbody" th:remove="all-but-first">
+        <attr sel="tr[0]" th:each="clientUser : ${clientUsers}">
+          <attr sel="td.user-id" th:text="${clientUser.userId}" />
+          <attr sel="td.nickname" th:text="${clientUser.nickname}" />
+		  <attr sel="td.agent-name" th:text="${clientUser.agentName}" />
+          <attr sel="#client-manage" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'}" />
+        </attr>
+      </attr>
+    </attr>
+
+    <attr sel="#pagination">
+      <attr sel="li[0]/a"
+            th:text="'previous'"
+            th:href="@{/manage(page=${clientUsers.number - 1}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
+            th:class="'page-link' + (${clientUsers.number} <= 0 ? ' disabled' : '')"
+      />
+      <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
+        <attr sel="a"
+              th:text="${pageNumber + 1}"
+              th:href="@{/manage(page=${pageNumber}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
+              th:class="'page-link' + (${pageNumber} == ${clientUsers.number} ? ' disabled' : '')"
+        />
+      </attr>
+      <attr sel="li[2]/a"
+            th:text="'next'"
+            th:href="@{/manage(page=${clientUsers.number + 1}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
+            th:class="'page-link' + (${clientUsers.number} >= ${clientUsers.totalPages - 1} ? ' disabled' : '')"
+      />
+    </attr>
+  </attr>
 </thlogic>

--- a/src/test/java/com/agencyplatformclonecoding/controller/ClientUserControllerTest.java
+++ b/src/test/java/com/agencyplatformclonecoding/controller/ClientUserControllerTest.java
@@ -175,6 +175,7 @@ class ClientUserControllerTest {
                 "테스트"
         );
     }
+
     private AgentDto createAgentDto() {
         return AgentDto.of(
                 createAgencyDto(),

--- a/src/test/java/com/agencyplatformclonecoding/service/ManageServiceTest.java
+++ b/src/test/java/com/agencyplatformclonecoding/service/ManageServiceTest.java
@@ -1,0 +1,297 @@
+package com.agencyplatformclonecoding.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.agencyplatformclonecoding.domain.Agency;
+import com.agencyplatformclonecoding.domain.Agent;
+import com.agencyplatformclonecoding.domain.AgentGroup;
+import com.agencyplatformclonecoding.domain.ClientUser;
+import com.agencyplatformclonecoding.domain.constrant.SearchType;
+import com.agencyplatformclonecoding.dto.*;
+import com.agencyplatformclonecoding.repository.AgencyRepository;
+import com.agencyplatformclonecoding.repository.AgentGroupRepository;
+import com.agencyplatformclonecoding.repository.AgentRepository;
+import com.agencyplatformclonecoding.repository.ClientUserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import javax.persistence.EntityNotFoundException;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@DisplayName("비즈니스 로직 - 광고 관리")
+@ExtendWith(MockitoExtension.class)
+class ManageServiceTest {
+
+    @InjectMocks
+    private ManageService sut;
+
+    @Mock
+    private AgentRepository agentRepository;
+    @Mock private AgentGroupRepository agentGroupRepository;
+    @Mock private AgencyRepository agencyRepository;
+    @Mock private ClientUserRepository clientUserRepository;
+
+    @DisplayName("READ - 광고주 조회 시 광고주 반환")
+    @Test
+    void givenAgentId_whenSearchingClientUser_thenReturnsClientUser() {
+        // Given
+        String clientId = "t-client";
+        ClientUser clientUser = createClientUser();
+        given(clientUserRepository.findById(clientId)).willReturn(Optional.of(clientUser));
+
+        // When
+        ClientUserDto dto = sut.getClientUser(clientId);
+
+        // Then
+        assertThat(dto)
+                .hasFieldOrPropertyWithValue("userId", clientUser.getUserId())
+                .hasFieldOrPropertyWithValue("nickname", clientUser.getNickname());
+        then(clientUserRepository).should().findById(clientId);
+    }
+
+    @DisplayName("READ - 검색어 없이 검색 시 광고주 리스트를 반환")
+    @Test
+    void givenNoSearchingParameter_whenSearchingClientUsers_thenReturnsClientUserPage() {
+        // Given
+        Pageable pageable = Pageable.ofSize(100);
+        given(clientUserRepository.findAll(pageable)).willReturn(Page.empty());
+
+        // When
+        Page<ClientUserDto> clientUsers = sut.searchClientUsers(null, null, pageable);
+
+        // Then
+        assertThat(clientUsers).isEmpty();
+        then(clientUserRepository).should().findAll(pageable);
+    }
+
+    @DisplayName("READ - 검색어를 통해 광고주 검색 시 광고주 리스트를 반환")
+    @Test
+    void givenSearchingParameter_whenSearchingClients_thenReturnsClientsPage() {
+        // Given
+        SearchType searchType = SearchType.ID;
+        String searchKeyword = "t-client";
+        Pageable pageable = Pageable.ofSize(100);
+        given(clientUserRepository.findByUserIdContaining(searchKeyword, pageable)).willReturn(Page.empty());
+
+        // When
+        Page<ClientUserDto> clientUsers = sut.searchClientUsers(searchType, searchKeyword, pageable);
+
+        // Then
+        assertThat(clientUsers).isEmpty();
+        then(clientUserRepository).should().findByUserIdContaining(searchKeyword, pageable);
+    }
+
+    @DisplayName("READ - 광고주 조회 시 광고주가 편성한 캠페인 리스트 반환")
+    @Test
+    void givenClientUserId_whenSearchingClientUserWithCampaigns_thenReturnsClientUserWithCampaigns() {
+        // Given
+        String clientId = "t-client";
+        ClientUser clientUser = createClientUser();
+        given(clientUserRepository.findById(clientId)).willReturn(Optional.of(clientUser));
+
+        // When
+        ClientUserWithCampaignsDto dto = sut.getClientUserWithCampaigns(clientId);
+
+        // Then
+        assertThat(dto)
+                .hasFieldOrPropertyWithValue("userId", clientUser.getUserId())
+                .hasFieldOrPropertyWithValue("nickname", clientUser.getNickname());
+        then(clientUserRepository).should().findById(clientId);
+    }
+
+    @DisplayName("READ - 캠페인을 가진 광고주가 없을 경우 예외 처리")
+    @Test
+    void givenNonexistentAgentId_whenSearchingAgentWithClients_thenReturnsAgentWithClients() {
+        // Given
+        String clientId = "none-client";
+        given(clientUserRepository.findById(clientId)).willReturn(Optional.empty());
+
+        // When
+        Throwable t= catchThrowable(() -> sut.getClientUserWithCampaigns(clientId));
+
+        // Then
+        assertThat(t)
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("광고주가 존재하지 않습니다 - clientId : " + clientId);
+        then(clientUserRepository).should().findById(clientId);
+    }
+
+    @DisplayName("READ - 광고주가 없을 경우 예외 처리")
+    @Test
+    void givenNonexistentClientUserId_whenSearchingClientUser_thenThrowsException() {
+        // Given
+        String clientId = "none-client";
+        given(clientUserRepository.findById(clientId)).willReturn(Optional.empty());
+
+        // When
+        Throwable t= catchThrowable(() -> sut.getClientUser(clientId));
+
+        // Then
+        assertThat(t)
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("광고주가 존재하지 않습니다 - clientId : " + clientId);
+        then(clientUserRepository).should().findById(clientId);
+    }
+
+    @DisplayName("READ - 광고주 수를 조회하면, 광고주 수를 반환한다")
+    @Test
+    void givenNothing_whenCountingClientUsers_thenReturnsClientUsersCount() {
+        // Given
+        long expected = 0L;
+        given(clientUserRepository.count()).willReturn(expected);
+
+        // When
+        long actual = sut.getClientUserCount();
+
+        // Then
+        assertThat(actual).isEqualTo(expected);
+        then(clientUserRepository).should().count();
+    }
+
+
+    // fixture
+
+    private Agency createAgency() {
+        Agency agency = Agency.of(
+                "t-agency",
+                "테스트용"
+        );
+
+        return agency;
+    }
+
+    private AgentGroup createAgentGroup() {
+        AgentGroup agentGroup = AgentGroup.of(
+                createAgency(),
+                "t-group",
+                "테스트용그룹"
+        );
+
+        return agentGroup;
+    }
+
+    private Agent createAgent() {
+        Agent agent = Agent.of(
+                createAgency(),
+                createAgentGroup(),
+                "t-agent",
+                "pw",
+                "email",
+                "테스트용"
+        );
+
+        return agent;
+    }
+
+    private ClientUser createClientUser() {
+        ClientUser clientUser = ClientUser.of(
+                createAgency(),
+                createAgent(),
+                "t-client",
+                "pw",
+                "email",
+                "테스트용"
+        );
+
+        return clientUser;
+    }
+
+    private List<ClientUser> clientUsers() {
+        List<ClientUser> clientUsers = Arrays.asList(createClientUser());
+
+        return clientUsers;
+    }
+
+    private AgencyDto createAgencyDto() {
+        return AgencyDto.of(
+                "t-agency",
+                "테스트용"
+        );
+    }
+
+    private AgentGroupDto createAgentGroupDto() {
+        return AgentGroupDto.of(
+                createAgencyDto(),
+                "t-group",
+                "테스트용",
+                LocalDateTime.now(),
+                "테스트",
+                LocalDateTime.now(),
+                "테스트"
+        );
+    }
+
+    private AgentGroupDto createModifiedAgentGroupDto(String agentGroupId) {
+        return AgentGroupDto.of(
+                createAgencyDto(),
+                agentGroupId,
+                "테스트용",
+                LocalDateTime.now(),
+                "테스트",
+                LocalDateTime.now(),
+                "테스트"
+        );
+    }
+    private AgentDto createAgentDto() {
+        return AgentDto.of(
+                createAgencyDto(),
+                createAgentGroupDto(),
+                "t-agent",
+                "pw",
+                "테스트용용",
+                "email",
+                LocalDateTime.now(),
+                "테스트",
+                LocalDateTime.now(),
+                "테스트"
+        );
+    }
+
+    private AgentDto createAgentDto(String agentGroupId) {
+        return AgentDto.of(
+                createAgencyDto(),
+                createModifiedAgentGroupDto(agentGroupId),
+                "t-agent",
+                "pw",
+                "테스트용용",
+                "email",
+                LocalDateTime.now(),
+                "테스트",
+                LocalDateTime.now(),
+                "테스트"
+        );
+    }
+
+    private AgentWithClientsDto createAgentWithClientsDto() {
+        return AgentWithClientsDto.of(
+                createAgencyDto(),
+                createAgentGroupDto(),
+                Set.of(),
+                "t-agent",
+                "pw",
+                "김테스트",
+                "email",
+                LocalDateTime.now(),
+                "테스트",
+                LocalDateTime.now(),
+                "테스트"
+        );
+    }
+
+}


### PR DESCRIPTION
광고 관리 페이지에서 광고주 영역의 기능을 구현한다.
* [x] 주요 기능 테스트
  * [x] 정렬 기능 (이름순 / 생성일자 순)
  * [x] 페이지네이션 기능
  * [x] 광고주 리스트 조회
  * [x] 광고주 상세 정보 조회 > 해당 광고주 캠페인 리스트 확인
* [x] 주요 기능 구현
  * [x] 정렬 기능 (이름순 / 생성일자 순)
  * [x] 페이지네이션 기능
  * [x] 광고주 리스트 조회
  * [x] 광고주 상세 정보 조회 > 해당 광고주 캠페인 리스트 확인
* [x] 디자인 적용
  * [x] 광고주 광고 관리 전체 페이지 (광고주 리스트)

This closes #39 