### PR TITLE
광고 관리 (캠페인/소재) 정렬/페이징 기능 구현

### DIFF
--- a/src/main/java/com/agencyplatformclonecoding/controller/ManageController.java
+++ b/src/main/java/com/agencyplatformclonecoding/controller/ManageController.java
@@ -1,6 +1,7 @@
 package com.agencyplatformclonecoding.controller;
 
 import com.agencyplatformclonecoding.domain.constrant.SearchType;
+import com.agencyplatformclonecoding.dto.response.CampaignResponse;
 import com.agencyplatformclonecoding.dto.response.ClientUserResponse;
 import com.agencyplatformclonecoding.dto.response.ClientUserWithCampaignsResponse;
 import com.agencyplatformclonecoding.service.*;
@@ -46,12 +47,19 @@ public class ManageController {
     }
 
     @GetMapping("/{clientId}/campaigns")
-    public String campaigns(@PathVariable String clientId, ModelMap map) {
+    public String campaigns(
+            @PathVariable String clientId,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            ModelMap map
+    ) {
+        Page<CampaignResponse> campaigns = campaignService.searchCampaigns(pageable, clientId).map(CampaignResponse::from);
         ClientUserWithCampaignsResponse clientUserWithCampaigns = ClientUserWithCampaignsResponse.from(manageService.getClientUserWithCampaigns(clientId));
+        List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), campaigns.getTotalPages());
 
         map.addAttribute("clientUser", clientUserWithCampaigns);
-        map.addAttribute("campaigns", clientUserWithCampaigns.campaignResponses());
-        map.addAttribute("totalCount", manageService.getClientUserCount());
+        map.addAttribute("campaigns", campaigns);
+        map.addAttribute("paginationBarNumbers", barNumbers);
+        map.addAttribute("totalCount", campaignService.getCampaignCount());
 
         return "manage/campaign";
     }

--- a/src/main/java/com/agencyplatformclonecoding/repository/CampaignRepository.java
+++ b/src/main/java/com/agencyplatformclonecoding/repository/CampaignRepository.java
@@ -24,7 +24,7 @@ public interface CampaignRepository extends
         QuerydslPredicateExecutor<Campaign>,
         QuerydslBinderCustomizer<QCampaign> {
 
-    Page<Campaign> findByDeletedFalse(Pageable pageable);
+    Page<Campaign> findByDeletedFalseAndClientUser_UserId(Pageable pageable, String clientId);
 
     Optional<Campaign> findByIdAndDeletedFalse(Long campaignId);
 

--- a/src/main/java/com/agencyplatformclonecoding/repository/CreativeRepository.java
+++ b/src/main/java/com/agencyplatformclonecoding/repository/CreativeRepository.java
@@ -24,7 +24,7 @@ public interface CreativeRepository extends
         QuerydslPredicateExecutor<Creative>,
         QuerydslBinderCustomizer<QCreative> {
 
-    Page<Creative> findByDeletedFalse(Pageable pageable);
+    Page<Creative> findByDeletedFalseAndCampaign_Id(Pageable pageable, Long campaignId);
 
     Optional<Creative> findByIdAndDeletedFalse(Long creativeId);
 

--- a/src/main/java/com/agencyplatformclonecoding/service/CampaignService.java
+++ b/src/main/java/com/agencyplatformclonecoding/service/CampaignService.java
@@ -40,8 +40,8 @@ public class CampaignService {
     }
 
     @Transactional(readOnly = true)
-    public Page<CampaignDto> searchCampaigns(Pageable pageable) {
-        return campaignRepository.findByDeletedFalse(pageable).map(CampaignDto::from);
+    public Page<CampaignDto> searchCampaigns(Pageable pageable, String clientId) {
+        return campaignRepository.findByDeletedFalseAndClientUser_UserId(pageable, clientId).map(CampaignDto::from);
     }
 
     public void saveCampaign(CampaignDto dto) {

--- a/src/main/java/com/agencyplatformclonecoding/service/CreativeService.java
+++ b/src/main/java/com/agencyplatformclonecoding/service/CreativeService.java
@@ -34,8 +34,8 @@ public class CreativeService {
     }
 
     @Transactional(readOnly = true)
-    public Page<CreativeDto> searchCreatives(Pageable pageable) {
-        return creativeRepository.findByDeletedFalse(pageable).map(CreativeDto::from);
+    public Page<CreativeDto> searchCreatives(Pageable pageable, Long campaignId) {
+        return creativeRepository.findByDeletedFalseAndCampaign_Id(pageable, campaignId).map(CreativeDto::from);
     }
 
     public void saveCreative(CreativeDto dto) {

--- a/src/main/resources/templates/manage/campaign.th.xml
+++ b/src/main/resources/templates/manage/campaign.th.xml
@@ -4,6 +4,8 @@
     <attr sel="#header" th:replace="header :: header"/>
     <attr sel="#footer" th:replace="footer :: footer"/>
 
+    <attr sel="main" th:object="${campaigns}">
+
     <attr sel="#create-campaign" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/form'}"/>
 
     <attr sel="#client-info">
@@ -15,6 +17,17 @@
     </attr>
 
     <attr sel="#campaign-table">
+      <attr sel="thead/tr">
+        <attr sel="th.activate-status/a" th:text="'상태'" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(
+      page=${campaigns.number},
+      sort='status' + (*{sort.getOrderFor('status')} != null ? (*{sort.getOrderFor('status').direction.name} != 'DESC' ? ',desc' : '') : '')
+  )}"/>
+        <attr sel="th.budget/a" th:text="'예산'" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(
+      page=${campaigns.number},
+      sort='budget' + (*{sort.getOrderFor('budget')} != null ? (*{sort.getOrderFor('budget').direction.name} != 'DESC' ? ',desc' : '') : '')
+  )}"/>
+      </attr>
+
       <attr sel="tbody" th:remove="all-but-first">
         <attr sel="tr[0]" th:each="campaign : ${campaigns}">
           <attr sel="#activate-button" th:text="${campaign.statusDescription}"/>
@@ -29,5 +42,25 @@
         </attr>
       </attr>
     </attr>
-</attr>
+
+    <attr sel="#pagination">
+      <attr sel="li[0]/a"
+            th:text="'previous'"
+            th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(page=${campaigns.number - 1})}"
+            th:class="'page-link' + (${campaigns.number} <= 0 ? ' disabled' : '')"
+      />
+      <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
+        <attr sel="a"
+              th:text="${pageNumber + 1}"
+              th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(page=${pageNumber})}"
+              th:class="'page-link' + (${pageNumber} == ${campaigns.number} ? ' disabled' : '')"
+        />
+      </attr>
+      <attr sel="li[2]/a"
+            th:text="'next'"
+            th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(page=${campaigns.number + 1})}"
+            th:class="'page-link' + (${campaigns.number} >= ${campaigns.totalPages - 1} ? ' disabled' : '')"
+      />
+    </attr>
+  </attr>
 </thlogic>

--- a/src/main/resources/templates/manage/creative.th.xml
+++ b/src/main/resources/templates/manage/creative.th.xml
@@ -4,6 +4,8 @@
   <attr sel="#header" th:replace="header :: header" />
   <attr sel="#footer" th:replace="footer :: footer" />
 
+  <attr sel="main" th:object="${creatives}">
+
   <attr sel="#creative-header/h1" th:text="'캠페인명 : ' + ${campaign.name}" />
 
   <attr sel="#create-creative" th:href="'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives/form'" />
@@ -17,6 +19,33 @@
   </attr>
 
     <attr sel="#creative-table">
+      <attr sel="thead/tr">
+        <attr sel="th.activate-status/a" th:text="'상태'" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(
+      page=${creatives.number},
+      sort='status' + (*{sort.getOrderFor('status')} != null ? (*{sort.getOrderFor('status').direction.name} != 'DESC' ? ',desc' : '') : '')
+  )}"/>
+        <attr sel="th.biding-price/a" th:text="'입찰가'" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(
+      page=${creatives.number},
+      sort='bidingPrice' + (*{sort.getOrderFor('bidingPrice')} != null ? (*{sort.getOrderFor('bidingPrice').direction.name} != 'DESC' ? ',desc' : '') : '')
+  )}"/>
+        <attr sel="th.view/a" th:text="'노출수'" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(
+      page=${creatives.number},
+      sort='view' + (*{sort.getOrderFor('view')} != null ? (*{sort.getOrderFor('view').direction.name} != 'DESC' ? ',desc' : '') : '')
+  )}"/>
+        <attr sel="th.click/a" th:text="'클릭수'" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(
+      page=${creatives.number},
+      sort='click' + (*{sort.getOrderFor('click')} != null ? (*{sort.getOrderFor('click').direction.name} != 'DESC' ? ',desc' : '') : '')
+  )}"/>
+        <attr sel="th.conversion/a" th:text="'전환수'" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(
+      page=${creatives.number},
+      sort='conversion' + (*{sort.getOrderFor('conversion')} != null ? (*{sort.getOrderFor('conversion').direction.name} != 'DESC' ? ',desc' : '') : '')
+  )}"/>
+        <attr sel="th.purchase/a" th:text="'구매액'" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(
+      page=${creatives.number},
+      sort='purchase' + (*{sort.getOrderFor('purchase')} != null ? (*{sort.getOrderFor('purchase').direction.name} != 'DESC' ? ',desc' : '') : '')
+  )}"/>
+      </attr>
+
       <attr sel="tbody" th:remove="all-but-first">
         <attr sel="tr[0]" th:each="creative : ${creatives}">
           <attr sel="#activate-button" th:text="${creative.statusDescription}"/>
@@ -34,5 +63,26 @@
         </attr>
       </attr>
     </attr>
+
+    <attr sel="#pagination">
+      <attr sel="li[0]/a"
+            th:text="'previous'"
+            th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(page=${creatives.number - 1})}"
+            th:class="'page-link' + (${creatives.number} <= 0 ? ' disabled' : '')"
+      />
+      <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
+        <attr sel="a"
+              th:text="${pageNumber + 1}"
+              th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(page=${pageNumber})}"
+              th:class="'page-link' + (${pageNumber} == ${creatives.number} ? ' disabled' : '')"
+        />
+      </attr>
+      <attr sel="li[2]/a"
+            th:text="'next'"
+            th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(page=${creatives.number + 1})}"
+            th:class="'page-link' + (${creatives.number} >= ${creatives.totalPages - 1} ? ' disabled' : '')"
+      />
+    </attr>
   </attr>
 </thlogic>
+

--- a/src/test/java/com/agencyplatformclonecoding/service/CampaignServiceTest.java
+++ b/src/test/java/com/agencyplatformclonecoding/service/CampaignServiceTest.java
@@ -61,14 +61,15 @@ public class CampaignServiceTest {
 	void givenNothing_whenSearchingCampaigns_thenReturnsCmpaigns() {
 		// Given
 		Pageable pageable = Pageable.ofSize(20);
-		given(campaignRepository.findByDeletedFalse(pageable)).willReturn(Page.empty());
+		String clientId = "t-client";
+		given(campaignRepository.findByDeletedFalseAndClientUser_UserId(pageable, clientId)).willReturn(Page.empty());
 
 		// When
-		Page<CampaignDto> campaigns = sut.searchCampaigns(pageable);
+		Page<CampaignDto> campaigns = sut.searchCampaigns(pageable, clientId);
 
 		// Then
 		assertThat(campaigns).isEmpty();
-		then(campaignRepository).should().findByDeletedFalse(pageable);
+		then(campaignRepository).should().findByDeletedFalseAndClientUser_UserId(pageable, clientId);
 	}
 
 	@DisplayName("READ - 캠페인 ID 조회 시 캠페인과 편성된 내부 소재 리스트 반환")

--- a/src/test/java/com/agencyplatformclonecoding/service/CreativeServiceTest.java
+++ b/src/test/java/com/agencyplatformclonecoding/service/CreativeServiceTest.java
@@ -66,14 +66,15 @@ public class CreativeServiceTest {
 	void givenNothing_whenSearchingCreatives_thenReturnsCreatives() {
 		// Given
 		Pageable pageable = Pageable.ofSize(20);
-		given(creativeRepository.findByDeletedFalse(pageable)).willReturn(Page.empty());
+		Long campaignId = 1L;
+		given(creativeRepository.findByDeletedFalseAndCampaign_Id(pageable, campaignId)).willReturn(Page.empty());
 
 		// When
-		Page<CreativeDto> creatives = sut.searchCreatives(pageable);
+		Page<CreativeDto> creatives = sut.searchCreatives(pageable, campaignId);
 
 		// Then
 		assertThat(creatives).isEmpty();
-		then(creativeRepository).should().findByDeletedFalse(pageable);
+		then(creativeRepository).should().findByDeletedFalseAndCampaign_Id(pageable, campaignId);
 	}
 
 	@DisplayName("READ - 소재가 존재하지 않을 경우 예외 처리")


### PR DESCRIPTION
1.0.0 버전에서 구현하지 못했던 캠페인, 소재 정렬 / 페이징 기능을 추가한다.
각 컨트롤러에서 하위 객체 페이지로 넘어갈 때 하위 객체를 Pageable 타입이 아닌 단순한 Response 타입으로 만들었기 때문에
정렬 및 페이징 기능이 구현되지 않고 있었음.

* [x] 컨트롤러 리팩토링 : 광고주 관리 > 캠페인, 캠페인 관리 > 소재 시 Pageable 타입으로 하위 객체를 생성할 수 있도록 변경
  * [x] 캠페인
  * [x] 소재 
* [x] 페이징 및 정렬 기능 구현
  * [x] 캠페인 : 예산순 / ON, OFF 상태 정렬
  * [x] 소재 : 소진액, 입찰가, 노출수, 클릭수, 전환수, 구매액수 정렬

This closes #65 