### PR TITLE
광고 관리 버그 수정

### DIFF
--- a/src/main/java/com/agencyplatformclonecoding/controller/CampaignController.java
+++ b/src/main/java/com/agencyplatformclonecoding/controller/CampaignController.java
@@ -62,6 +62,7 @@ public class CampaignController {
             @PathVariable Long campaignId,
             ModelMap map
     ) {
+        campaignService.validateClientAndCampaign(campaignId, clientId);
         CampaignResponse campaign = CampaignResponse.from(campaignService.getCampaign(campaignId));
         ClientUserWithCampaignsResponse clientUser = ClientUserWithCampaignsResponse.from(manageService.getClientUserWithCampaigns(clientId));
 
@@ -78,7 +79,7 @@ public class CampaignController {
             @PathVariable Long campaignId,
             CampaignRequest campaignRequest
     ) {
-        campaignService.updateCampaign(campaignId, campaignRequest.toDto(ClientUserDto.of(clientId)));  // TODO : 추후 에이전시 인증 기능 부여
+        campaignService.updateCampaign(campaignId, clientId, campaignRequest.toDto(ClientUserDto.of(clientId)));
 
         return "redirect:/manage/{clientId}/campaigns";
     }
@@ -88,7 +89,7 @@ public class CampaignController {
             @PathVariable("clientId") String clientId,
             @PathVariable Long campaignId
     ) {
-        campaignService.deleteCampaign(campaignId);
+        campaignService.deleteCampaign(campaignId, clientId);
 
         return "redirect:/manage/{clientId}/campaigns";
     }
@@ -100,7 +101,7 @@ public class CampaignController {
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             ModelMap map
     ) {
-        Page<CreativeResponse> creatives = creativeService.searchCreatives(pageable, campaignId).map(CreativeResponse::from);
+        Page<CreativeResponse> creatives = creativeService.searchCreatives(pageable, campaignId, clientId).map(CreativeResponse::from);
         CampaignResponse campaign = CampaignResponse.from(campaignService.getCampaign(campaignId));
         ClientUserWithCampaignsResponse clientUserWithCampaignsResponse = ClientUserWithCampaignsResponse.from(manageService.getClientUserWithCampaigns(clientId));
         List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), creatives.getTotalPages());
@@ -113,6 +114,4 @@ public class CampaignController {
 
         return "manage/creative";
     }
-
 }
-

--- a/src/main/java/com/agencyplatformclonecoding/controller/CreativeController.java
+++ b/src/main/java/com/agencyplatformclonecoding/controller/CreativeController.java
@@ -35,6 +35,12 @@ public class CreativeController {
             @PathVariable("campaignId") Long campaignId,
             ModelMap map
     ) {
+        try {
+            creativeService.validateClientAndCampaign(campaignId, clientId);
+        } catch(IllegalArgumentException e) {
+            return "잘못된 경로입니다.";
+        }
+
         CampaignWithCreativesResponse campaign = CampaignWithCreativesResponse.from(campaignService.getCampaignWithCreatives(campaignId));
         ClientUserWithCampaignsResponse clientUser = ClientUserWithCampaignsResponse.from(manageService.getClientUserWithCampaigns(clientId));
 
@@ -51,6 +57,7 @@ public class CreativeController {
             @PathVariable("campaignId") Long campaignId,
             CreativeRequest creativeRequest
     ) {
+        creativeService.validateClientAndCampaign(campaignId, clientId);
         creativeService.saveCreative(creativeRequest.toDto(CampaignDto.of(campaignId)));
 
         return "redirect:/manage/{clientId}/campaigns/{campaignId}/creatives";
@@ -63,6 +70,7 @@ public class CreativeController {
             @PathVariable Long creativeId,
             ModelMap map
     ) {
+        creativeService.validateClientAndCampaignAndCreative(creativeId, campaignId, clientId);
         CreativeResponse creative = CreativeResponse.from(creativeService.getCreative(creativeId));
         CampaignWithCreativesResponse campaign = CampaignWithCreativesResponse.from(campaignService.getCampaignWithCreatives(campaignId));
         ClientUserWithCampaignsResponse clientUser = ClientUserWithCampaignsResponse.from(manageService.getClientUserWithCampaigns(clientId));
@@ -82,7 +90,8 @@ public class CreativeController {
             @PathVariable Long creativeId,
             CreativeRequest creativeRequest
     ) {
-        creativeService.updateCreative(creativeId, creativeRequest.toDto(CampaignDto.of(campaignId)));  // TODO : 추후 에이전시 인증 기능 부여
+        creativeService.validateClientAndCampaignAndCreative(creativeId, campaignId, clientId);
+        creativeService.updateCreative(creativeId, campaignId, clientId, creativeRequest.toDto(CampaignDto.of(campaignId)));  // TODO : 추후 에이전시 인증 기능 부여
 
         return "redirect:/manage/{clientId}/campaigns/{campaignId}/creatives";
     }
@@ -93,7 +102,8 @@ public class CreativeController {
             @PathVariable("campaignId") Long campaignId,
             @PathVariable Long creativeId
     ) {
-        creativeService.deleteCreative(creativeId);
+        creativeService.validateClientAndCampaignAndCreative(creativeId, campaignId, clientId);
+        creativeService.deleteCreative(creativeId, campaignId, clientId);
 
         return "redirect:/manage/{clientId}/campaigns/{campaignId}/creatives";
     }

--- a/src/test/java/com/agencyplatformclonecoding/controller/CampaignControllerTest.java
+++ b/src/test/java/com/agencyplatformclonecoding/controller/CampaignControllerTest.java
@@ -156,7 +156,7 @@ class CampaignControllerTest {
         String clientId = "client";
         Long campaignId = 1L;
         CampaignRequest campaignRequest = CampaignRequest.of("새 캠페인", 1000L);
-        willDoNothing().given(campaignService).updateCampaign(eq(campaignId), any(CampaignDto.class));
+        willDoNothing().given(campaignService).updateCampaign(eq(campaignId), eq(clientId), any(CampaignDto.class));
 
         // When & Then
         mvc.perform(
@@ -168,7 +168,7 @@ class CampaignControllerTest {
                 .andExpect(status().is3xxRedirection())
                 .andExpect(view().name("redirect:/manage/{clientId}/campaigns"))
                 .andExpect(redirectedUrl("/manage/client/campaigns"));
-        then(campaignService).should().updateCampaign(eq(campaignId), any(CampaignDto.class));
+        then(campaignService).should().updateCampaign(eq(campaignId), eq(clientId), any(CampaignDto.class));
     }
 
     // fixture

--- a/src/test/java/com/agencyplatformclonecoding/service/CampaignServiceTest.java
+++ b/src/test/java/com/agencyplatformclonecoding/service/CampaignServiceTest.java
@@ -153,7 +153,7 @@ public class CampaignServiceTest {
 		given(campaignRepository.getReferenceById(dto.id())).willReturn(campaign);
 
 		// When
-		sut.updateCampaign(dto.id(), dto);
+		sut.updateCampaign(dto.id(), dto.clientUserDto().userId(), dto);
 
 		// Then
 		assertThat(campaign)
@@ -175,7 +175,7 @@ public class CampaignServiceTest {
 		given(campaignRepository.getReferenceById(dto.id())).willReturn(campaign);
 
 		// When
-		sut.updateCampaign(dto.id(), dto);
+		sut.updateCampaign(dto.id(), dto.clientUserDto().userId(), dto);
 
 		// Then
 		assertThat(campaign)
@@ -192,7 +192,7 @@ public class CampaignServiceTest {
 		given(campaignRepository.getReferenceById(dto.id())).willThrow(EntityNotFoundException.class);
 
 		// When
-		sut.updateCampaign(dto.id(), dto);
+		sut.updateCampaign(dto.id(), dto.clientUserDto().userId(), dto);
 
 		// Then
 		then(campaignRepository).should().getReferenceById(dto.id());
@@ -203,10 +203,11 @@ public class CampaignServiceTest {
 	void givenCampaignId_whenDeletingCampaign_thenDeletesCampaign() {
 		// Given
 		Long campaignId = 1L;
+		String clientId = "t-test";
 		willDoNothing().given(campaignRepository).setCampaignDeletedTrue(campaignId);
 
 		// When
-		sut.deleteCampaign(campaignId);
+		sut.deleteCampaign(campaignId, clientId);
 
 		// Then
 		then(campaignRepository).should().setCampaignDeletedTrue(campaignId);

--- a/src/test/java/com/agencyplatformclonecoding/service/CreativeServiceTest.java
+++ b/src/test/java/com/agencyplatformclonecoding/service/CreativeServiceTest.java
@@ -67,10 +67,11 @@ public class CreativeServiceTest {
 		// Given
 		Pageable pageable = Pageable.ofSize(20);
 		Long campaignId = 1L;
+		String clientId = "t-client";
 		given(creativeRepository.findByDeletedFalseAndCampaign_Id(pageable, campaignId)).willReturn(Page.empty());
 
 		// When
-		Page<CreativeDto> creatives = sut.searchCreatives(pageable, campaignId);
+		Page<CreativeDto> creatives = sut.searchCreatives(pageable, campaignId, clientId);
 
 		// Then
 		assertThat(creatives).isEmpty();
@@ -136,7 +137,7 @@ public class CreativeServiceTest {
 		given(creativeRepository.getReferenceById(dto.id())).willReturn(creative);
 
 		// When
-		sut.updateCreative(dto.id(), dto);
+		sut.updateCreative(dto.id(), dto.campaignDto().id(), dto.campaignDto().clientUserDto().userId(), dto);
 
 		// Then
 		assertThat(creative)
@@ -156,7 +157,7 @@ public class CreativeServiceTest {
 		given(creativeRepository.getReferenceById(dto.id())).willReturn(creative);
 
 		// When
-		sut.updateCreative(dto.id(), dto);
+		sut.updateCreative(dto.id(), dto.campaignDto().id(), dto.campaignDto().clientUserDto().userId(), dto);
 
 		// Then
 		assertThat(creative)
@@ -173,7 +174,7 @@ public class CreativeServiceTest {
 		given(creativeRepository.getReferenceById(dto.id())).willThrow(EntityNotFoundException.class);
 
 		// When
-		sut.updateCreative(dto.id(), dto);
+		sut.updateCreative(dto.id(), dto.campaignDto().id(), dto.campaignDto().clientUserDto().userId(), dto);
 
 		// Then
 		then(creativeRepository).should().getReferenceById(dto.id());
@@ -184,10 +185,12 @@ public class CreativeServiceTest {
 	void givenCreativeId_whenDeletingCreative_thenDeletesCreative() {
 		// Given
 		Long creativeId = 1L;
+		Long campaignId = 1L;
+		String clientId = "t-client";
 		willDoNothing().given(creativeRepository).setCreativeDeletedTrue(creativeId);
 
 		// When
-		sut.deleteCreative(creativeId);
+		sut.deleteCreative(creativeId, campaignId, clientId);
 
 		// Then
 		then(creativeRepository).should().setCreativeDeletedTrue(creativeId);


### PR DESCRIPTION
Controller와 Service 내부 메소드들에 대해 상위 객체의 id까지 모두 받게 하고 Service에는 validation 기능을 하는 메소드를 추가하였음. 잘못된 URI로 접근 시 Exception 발생

* [x] 광고주 - 캠페인 - 소재 일치 검증 기능 점검 및 수정
  * [x] Repository 수정 (캠페인 / 소재)
  * [x] Service 수정 (캠페인 / 소재)
  * [x] Controller 수정 (Campaign -> Creative로 넘어갈 시)