### PR TITLE
광고 관리 (실적) 페이지 및 기능 일부 구현

### DIFF
--- a/src/main/java/com/agencyplatformclonecoding/controller/PerformanceController.java
+++ b/src/main/java/com/agencyplatformclonecoding/controller/PerformanceController.java
@@ -1,0 +1,22 @@
+package com.agencyplatformclonecoding.controller;
+
+import com.agencyplatformclonecoding.service.CampaignService;
+import com.agencyplatformclonecoding.service.CreativeService;
+import com.agencyplatformclonecoding.service.ManageService;
+import com.agencyplatformclonecoding.service.PerformanceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequiredArgsConstructor
+@RequestMapping(value = "/manage/{clientId}/campaigns/{campaignId}/creatives/{creativeId}/performances")
+@Controller
+public class PerformanceController {
+
+    private final ManageService manageService;
+    private final CampaignService campaignService;
+    private final CreativeService creativeService;
+    private final PerformanceService performanceService;
+
+    // TODO :: 통계 / 보고서 관련 기능 추가 예정
+}

--- a/src/main/java/com/agencyplatformclonecoding/exception/ErrorCode.java
+++ b/src/main/java/com/agencyplatformclonecoding/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     CLIENT_NOT_FOUND(HttpStatus.NOT_FOUND, "Client not founded"),
     CAMPAIGN_NOT_FOUND(HttpStatus.NOT_FOUND, "Campaign not founded"),
     CREATIVE_NOT_FOUND(HttpStatus.NOT_FOUND, "Campaign not founded"),
+    PERFORMANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Performance not founded"),
     AGENT_EXISTS(HttpStatus.CONFLICT, "Agent exists"),
     CLIENT_EXISTS(HttpStatus.CONFLICT, "Client exists"),
     INVALID_RELATION(HttpStatus.CONFLICT, "Client, Campaign, Creative does not match with each other"),

--- a/src/main/java/com/agencyplatformclonecoding/service/CreativeService.java
+++ b/src/main/java/com/agencyplatformclonecoding/service/CreativeService.java
@@ -4,6 +4,7 @@ import com.agencyplatformclonecoding.domain.Campaign;
 import com.agencyplatformclonecoding.domain.ClientUser;
 import com.agencyplatformclonecoding.domain.Creative;
 import com.agencyplatformclonecoding.dto.CreativeDto;
+import com.agencyplatformclonecoding.dto.CreativeWithPerformancesDto;
 import com.agencyplatformclonecoding.exception.AdPlatformException;
 import com.agencyplatformclonecoding.exception.ErrorCode;
 import com.agencyplatformclonecoding.repository.CampaignRepository;
@@ -101,6 +102,13 @@ public class CreativeService {
         if (!campaign.getClientUser().equals(clientUser)) {
             throw new AdPlatformException(ErrorCode.INVALID_RELATION);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public CreativeWithPerformancesDto getCreativeWithPerformances(Long creativeId) {
+        return creativeRepository.findByIdAndDeletedFalse(creativeId)
+                .map(CreativeWithPerformancesDto::from)
+                .orElseThrow(() -> new AdPlatformException(ErrorCode.CREATIVE_NOT_FOUND));
     }
 
     public void validateClientAndCampaignAndCreative(Long creativeId, Long campaignId, String clientId) {

--- a/src/main/java/com/agencyplatformclonecoding/service/PerformanceService.java
+++ b/src/main/java/com/agencyplatformclonecoding/service/PerformanceService.java
@@ -1,0 +1,74 @@
+package com.agencyplatformclonecoding.service;
+
+import com.agencyplatformclonecoding.domain.Campaign;
+import com.agencyplatformclonecoding.domain.ClientUser;
+import com.agencyplatformclonecoding.domain.Creative;
+import com.agencyplatformclonecoding.domain.constrant.SearchType;
+import com.agencyplatformclonecoding.dto.ClientUserDto;
+import com.agencyplatformclonecoding.dto.ClientUserWithCampaignsDto;
+import com.agencyplatformclonecoding.dto.PerformanceDto;
+import com.agencyplatformclonecoding.exception.AdPlatformException;
+import com.agencyplatformclonecoding.exception.ErrorCode;
+import com.agencyplatformclonecoding.repository.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class PerformanceService {
+
+    private final CampaignRepository campaignRepository;
+    private final CreativeRepository creativeRepository;
+    private final ClientUserRepository clientUserRepository;
+	private final PerformanceRepository performanceRepository;
+
+    @Transactional(readOnly = true)
+    public PerformanceDto getPerformance(Long performanceId) {
+        return performanceRepository.findById(performanceId)
+                .map(PerformanceDto::from)
+                .orElseThrow(() -> new AdPlatformException(ErrorCode.PERFORMANCE_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<PerformanceDto> searchPerformances(Pageable pageable, Long creativeId, Long campaignId, String clientId) {
+        validateClientAndCampaignAndCreative(creativeId, campaignId, clientId);
+        return performanceRepository.findByCreative_Id(pageable, creativeId).map(PerformanceDto::from);
+    }
+
+    public long getPerformanceCount() {
+        return performanceRepository.count();
+    }
+
+    public void validateClientAndCampaign(Long campaignId, String clientId) {
+
+        Campaign campaign = campaignRepository.getReferenceById(campaignId);
+        ClientUser clientUser = clientUserRepository.getReferenceById(clientId);
+
+        if (!campaign.getClientUser().equals(clientUser)) {
+            throw new AdPlatformException(ErrorCode.INVALID_RELATION);
+        }
+    }
+
+    public void validateClientAndCampaignAndCreative(Long creativeId, Long campaignId, String clientId) {
+
+        Creative creative = creativeRepository.getReferenceById(creativeId);
+        Campaign campaign = campaignRepository.getReferenceById(campaignId);
+        ClientUser clientUser = clientUserRepository.getReferenceById(clientId);
+
+        if (!campaign.getClientUser().equals(clientUser)) {
+            throw new AdPlatformException(ErrorCode.INVALID_RELATION);
+        }
+
+        if (!creative.getCampaign().equals(campaign)) {
+            throw new AdPlatformException(ErrorCode.INVALID_RELATION);
+        }
+    }
+
+}
+

--- a/src/main/resources/templates/manage/creative.html
+++ b/src/main/resources/templates/manage/creative.html
@@ -103,7 +103,7 @@
           <th class="id"><a>소재 번호</a></th>
           <th class="keyword"><a>소재 키워드</a></th>
           <th class="biding-price"><a>입찰가(원)</a></th>
-          <th class="manage" colspan="2"><a></a></th>
+          <th class="manage" colspan="3"><a></a></th>
         </tr>
         </thead>
         <tbody>
@@ -123,6 +123,7 @@
               <button class="btn btn-danger me-md-2" role="button" id="delete-creative">소재 삭제</button>
             </form>
           </td>
+          <td class="button"><a class="btn btn-info" role="button" id="performance-info">성과 확인</a></td>
         </tr>
         <tr>
           <td class="id">2</td>
@@ -134,6 +135,7 @@
               <button class="btn btn-danger me-md-2" role="button" id="delete-creative">소재 삭제</button>
             </form>
           </td>
+          <td class="button"><a class="btn btn-info" role="button" id="performance-info">성과 확인</a></td>
         <tr>
           <td class="id">3</td>
           <td class="keyword">코코볼관리</td>
@@ -144,6 +146,7 @@
               <button class="btn btn-danger me-md-2" role="button" id="delete-creative">소재 삭제</button>
             </form>
           </td>
+          <td class="button"><a class="btn btn-info" role="button" id="performance-info">성과 확인</a></td>
         </tr>
         </tbody>
       </table>

--- a/src/main/resources/templates/manage/creative.th.xml
+++ b/src/main/resources/templates/manage/creative.th.xml
@@ -40,6 +40,7 @@
           <attr sel="td.biding-price" th:text="${creative.bidingPrice}" />
           <attr sel="#manage-creative" th:href="'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives/' + ${creative.id} + '/form'" />
           <attr sel="#delete-creative-form" th:action="'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives/' + ${creative.id} + '/delete'" th:method="post" />
+          <attr sel="#performance-info" th:href="'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives/' + ${creative.id} + '/performances'"/>
         </attr>
       </attr>
     </attr>

--- a/src/main/resources/templates/manage/performance.html
+++ b/src/main/resources/templates/manage/performance.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <meta name="description" content="">
+  <meta name="author" content="mrcocoball">
+  <title>소재 실적</title>
+
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+</head>
+
+<body>
+
+<header id="header">
+  헤더 삽입부
+  <hr>
+</header>
+
+<main class="d-flex flex-nowrap">
+  <div class="d-flex flex-column flex-shrink-0 p-3 text-bg-dark" style="min-height: 865px; width: 280px;">
+    <a href="/" class="d-flex align-items-center mb-0 mb-md-0 me-md-auto text-white text-decoration-none">
+      <svg class="bi pe-none me-2" width="40" height="32">
+        <use xlink:href="#bootstrap"/>
+      </svg>
+      <span class="fs-4"></span>
+    </a>
+    <ul class="nav nav-pills flex-column mb-auto">
+      <li class="nav-item">
+        <a href="/agents" class="nav-link text-white">
+          <svg class="bi pe-none me-2" width="16" height="16">
+            <use xlink:href="#home"/>
+          </svg>
+          에이전트 관리
+        </a>
+      </li>
+      <li>
+        <a href="/agentGroups" class="nav-link text-white">
+          <svg class="bi pe-none me-2" width="16" height="16">
+            <use xlink:href="#speedometer2"/>
+          </svg>
+          에이전트 그룹 관리
+        </a>
+      </li>
+      <li>
+        <a href="/clients" class="nav-link text-white">
+          <svg class="bi pe-none me-2" width="16" height="16">
+            <use xlink:href="#table"/>
+          </svg>
+          광고주 관리
+        </a>
+      </li>
+      <li>
+        <a href="/manage" class="nav-link active" aria-current="page">
+          <svg class="bi pe-none me-2" width="16" height="16">
+            <use xlink:href="#grid"/>
+          </svg>
+          광고 관리
+        </a>
+      </li>
+      <li>
+        <a href="#" class="nav-link text-white">
+          <svg class="bi pe-none me-2" width="16" height="16">
+            <use xlink:href="#people-circle"/>
+          </svg>
+          대시보드
+        </a>
+      </li>
+  </div>
+
+  <div class="container">
+    <header id="performance-header">
+      <h1> 소재 실적 페이지 </h1>
+    </header>
+
+    <div class="row">
+      <table class="table" id="client-info">
+        <thead>
+        <tr>
+          <th class="user-id col-xs-2"><a>광고주 ID</a></th>
+          <th class="nickname col-xs-2"><a>광고주명</a></th>
+          <th class="category col-xs-2"><a>업종</a></th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <td class="user-id"><a>client1</a></td>
+          <td class="nickname">코코볼자동차</td>
+          <td class="category">자동차</td>
+        </tr>
+        </tbody>
+      </table>
+
+      <table class="table" id="creative-info">
+        <thead>
+        <tr>
+          <th class="activate-status" style="width: 80px;"><a>상태</a></th>
+          <th class="id"><a>소재 번호</a></th>
+          <th class="keyword"><a>소재 키워드</a></th>
+          <th class="biding-price"><a>입찰가(원)</a></th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <td>
+            <button class="btn btn-primary active" role="buttion" id="activate-button">ON</button>
+          </td>
+          <td class="id">1</td>
+          <td class="keyword">코코볼추천</td>
+          <td class="biding-price">30000</td>
+        </tr>
+        </tbody>
+      </table>
+
+	  <table class="table" id="performance-table">
+        <thead>
+        <tr>
+          <th class="date" style="width: 200px;"><a>날짜</a></th>
+          <th class="view"><a>노출수</a></th>
+          <th class="click"><a>클릭수</a></th>
+          <th class="conversion"><a>전환수</a></th>
+          <th class="purchase"><a>구매액</a></th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <td class="date">2022-08-03</td>
+          <td class="view"><a>1000</a></td>
+          <td class="click"><a>100</a></td>
+          <td class="conversion"><a>10</a></td>
+          <td class="purchase"><a>100000</a></td>
+        </tr>
+        <tr>
+          <td class="date">2022-08-02</td>
+          <td class="view"><a>1000</a></td>
+          <td class="click"><a>100</a></td>
+          <td class="conversion"><a>10</a></td>
+          <td class="purchase"><a>100000</a></td>
+        </tr>
+        <tr>
+          <td class="date">2022-08-01</td>
+          <td class="view"><a>1000</a></td>
+          <td class="click"><a>100</a></td>
+          <td class="conversion"><a>10</a></td>
+          <td class="purchase"><a>100000</a></td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="row">
+      <nav id="pagination" aria-label="Page navigation">
+        <ul class="pagination justify-content-center">
+          <li class="page-item"><a class="page-link" href="#">Previous</a></li>
+          <li class="page-item"><a class="page-link" href="#">1</a></li>
+          <li class="page-item"><a class="page-link" href="#">Next</a></li>
+        </ul>
+      </nav>
+    </div>
+</main>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-A3rJD856KowSb7dwlZdYEkO39Gagi7vIsF0jrRAoQmDKKtQBHUuLZ9AsSv4jD4Xa"
+        crossorigin="anonymous"></script>
+
+</body>

--- a/src/main/resources/templates/manage/performance.th.xml
+++ b/src/main/resources/templates/manage/performance.th.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<thlogic>
+  <attr sel="head" th:replace="head :: head" />
+  <attr sel="#header" th:replace="header :: header" />
+  <attr sel="#footer" th:replace="footer :: footer" />
+
+  <attr sel="main" th:object="${performances}">
+
+  <attr sel="#performance-header/h1" th:text="'소재 키워드 : ' + ${creative.keyword}" />
+
+  <attr sel="#client-info">
+    <attr sel="tbody" th:remove="all-but-first">
+      <attr sel="td.user-id" th:text="${clientUser.userId}" />
+      <attr sel="td.nickname" th:text="${clientUser.nickname}" />
+      <attr sel="td.category" th:text="${clientUser.categoryName}"/>
+    </attr>
+  </attr>
+
+  <attr sel="#creative-info">
+    <attr sel="tbody" th:remove="all-but-first">
+      <attr sel="#activate-button" th:text="${creative.activated} != true ? 'OFF' : 'ON'"/>
+      <attr sel="#activate-button" th:classappend="${creative.activated} != true ? 'btn btn-danger active' : 'btn btn-primary active'"/>
+      <attr sel="td.id" th:text="${creative.id}" />
+      <attr sel="td.keyword" th:text="${creative.keyword}" />
+      <attr sel="td.biding-price" th:text="${creative.bidingPrice}"/>
+    </attr>
+  </attr>
+
+  <attr sel="#performance-table">
+      <attr sel="tbody" th:remove="all-but-first">
+        <attr sel="tr[0]" th:each="performance : ${performances}">
+          <attr sel="td.date" th:text="${performance.createdAt}" />
+          <attr sel="td.view" th:text="${performance.view}" />
+          <attr sel="td.click" th:text="${performance.click}" />
+          <attr sel="td.conversion" th:text="${performance.conversion}" />
+          <attr sel="td.purchase" th:text="${performance.purchase}"/>
+        </attr>
+      </attr>
+    </attr>
+
+    <attr sel="#pagination">
+      <attr sel="li[0]/a"
+            th:text="'previous'"
+            th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives/' + ${creative.id} + '/performances'(page=${performances.number - 1})}"
+            th:class="'page-link' + (${performances.number} <= 0 ? ' disabled' : '')"
+      />
+      <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
+        <attr sel="a"
+              th:text="${pageNumber + 1}"
+              th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives/' + ${creative.id} + '/performances'(page=${pageNumber})}"
+              th:class="'page-link' + (${pageNumber} == ${performances.number} ? ' disabled' : '')"
+        />
+      </attr>
+      <attr sel="li[2]/a"
+            th:text="'next'"
+            th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives/' + ${creative.id} + '/performances'(page=${performances.number + 1})}"
+            th:class="'page-link' + (${performances.number} >= ${performances.totalPages - 1} ? ' disabled' : '')"
+      />
+    </attr>
+  </attr>
+</thlogic>


### PR DESCRIPTION
소재의 상세 실적을 확인할 수 있는 실적 페이지를 구현한다.
광고 관리 > 광고주 > 캠페인 > 소재 > 실적 순으로 연결이 된다.
일단 일자별 통계 기능을 아직 만들지 않았으므로 페이징 기능만 적용하고 최신순 정렬을 적용시킨다.

* [x] 주요 기능 구현
  * [x] 페이지네이션 기능
  * [x] 실적 리스트 조회
* [x] 디자인 적용
  * [x] 실적 페이지

This closes #80 