### PR TITLE
숫자 표기 방식 변경

### DIFF
--- a/src/main/java/com/agencyplatformclonecoding/dto/CampaignDto.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/CampaignDto.java
@@ -3,6 +3,7 @@ package com.agencyplatformclonecoding.dto;
 import com.agencyplatformclonecoding.domain.Campaign;
 import com.agencyplatformclonecoding.domain.ClientUser;
 
+import java.text.DecimalFormat;
 import java.time.LocalDateTime;
 
 public record CampaignDto(
@@ -10,6 +11,7 @@ public record CampaignDto(
         Long id,
         String name,
         Long budget,
+        String sBudget,
         LocalDateTime createdAt,
         String createdBy,
         LocalDateTime modifiedAt,
@@ -18,30 +20,36 @@ public record CampaignDto(
 ) {
 
     public static CampaignDto of(ClientUserDto clientUserDto, String name, Long budget) {
-        return new CampaignDto(clientUserDto, null, name, budget, null, null, null, null, false);
+
+        String sBudget = formatToString(budget);
+
+        return new CampaignDto(clientUserDto, null, name, budget, sBudget, null, null, null, null, false);
     }
 
     public static CampaignDto of(Long id) {
-        return new CampaignDto(null, id, null, null, null, null, null, null, false);
+        return new CampaignDto(null, id, null, null, null, null, null, null, null, false);
     }
 
-    public static CampaignDto of(ClientUserDto clientUserDto, Long id, String name, Long budget, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy, boolean activated) {
-        return new CampaignDto(clientUserDto, id, name, budget, createdAt, createdBy, modifiedAt, modifiedBy, activated);
+    public static CampaignDto of(ClientUserDto clientUserDto, Long id, String name, Long budget, String sBudget, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy, boolean activated) {
+        return new CampaignDto(clientUserDto, id, name, budget, sBudget, createdAt, createdBy, modifiedAt, modifiedBy, activated);
     }
 
     // Entity -> dto로 변환
     public static CampaignDto from(Campaign entity) {
+
+        String sBudget = formatToString(entity.getBudget());
+
         return new CampaignDto(
                 ClientUserDto.from(entity.getClientUser()),
                 entity.getId(),
                 entity.getName(),
                 entity.getBudget(),
+                sBudget,
                 entity.getCreatedAt(),
                 entity.getCreatedBy(),
                 entity.getModifiedAt(),
                 entity.getModifiedBy(),
-				entity.isActivated()
-
+                entity.isActivated()
         );
     }
 
@@ -52,5 +60,10 @@ public record CampaignDto(
                 name,
                 budget
         );
+    }
+
+    public static String formatToString(Long amount) {
+        DecimalFormat df = new DecimalFormat("###,###");
+        return df.format(amount);
     }
 }

--- a/src/main/java/com/agencyplatformclonecoding/dto/CampaignWithCreativesDto.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/CampaignWithCreativesDto.java
@@ -2,6 +2,7 @@ package com.agencyplatformclonecoding.dto;
 
 import com.agencyplatformclonecoding.domain.Campaign;
 
+import java.text.DecimalFormat;
 import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -12,6 +13,7 @@ public record CampaignWithCreativesDto(
         Long id,
         String name,
         Long budget,
+        String sBudget,
         LocalDateTime createdAt,
         String createdBy,
         LocalDateTime modifiedAt,
@@ -20,17 +22,21 @@ public record CampaignWithCreativesDto(
         boolean activated
 ) {
 
-    public static CampaignWithCreativesDto of(ClientUserDto clientUserDto, Long id, String name, Long budget, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy, Set<CreativeDto> creativeDtos, boolean activated) {
-        return new CampaignWithCreativesDto(clientUserDto, id, name, budget, createdAt, createdBy, modifiedAt, modifiedBy, creativeDtos, activated);
+    public static CampaignWithCreativesDto of(ClientUserDto clientUserDto, Long id, String name, Long budget, String sBudget, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy, Set<CreativeDto> creativeDtos, boolean activated) {
+        return new CampaignWithCreativesDto(clientUserDto, id, name, budget, sBudget, createdAt, createdBy, modifiedAt, modifiedBy, creativeDtos, activated);
     }
 
     // Entity -> dto로 변환
     public static CampaignWithCreativesDto from(Campaign entity) {
+
+        String sBudget = formatToString(entity.getBudget());
+
         return new CampaignWithCreativesDto(
                 ClientUserDto.from(entity.getClientUser()),
                 entity.getId(),
                 entity.getName(),
                 entity.getBudget(),
+                sBudget,
                 entity.getCreatedAt(),
                 entity.getCreatedBy(),
                 entity.getModifiedAt(),
@@ -39,7 +45,12 @@ public record CampaignWithCreativesDto(
                         .filter(c -> !c.isDeleted())
                         .map(CreativeDto::from)
                         .collect(Collectors.toCollection(LinkedHashSet::new)),
-				entity.isActivated()
+                entity.isActivated()
         );
+    }
+
+    public static String formatToString(Long amount) {
+        DecimalFormat df = new DecimalFormat("###,###");
+        return df.format(amount);
     }
 }

--- a/src/main/java/com/agencyplatformclonecoding/dto/CreativeDto.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/CreativeDto.java
@@ -3,6 +3,7 @@ package com.agencyplatformclonecoding.dto;
 import com.agencyplatformclonecoding.domain.Campaign;
 import com.agencyplatformclonecoding.domain.Creative;
 
+import java.text.DecimalFormat;
 import java.time.LocalDateTime;
 
 public record CreativeDto(
@@ -11,6 +12,7 @@ public record CreativeDto(
         Long id,
         String keyword,
         Long bidingPrice,
+        String sBidingPrice,
         LocalDateTime createdAt,
         String createdBy,
         LocalDateTime modifiedAt,
@@ -19,26 +21,33 @@ public record CreativeDto(
 ) {
 
     public static CreativeDto of(CampaignDto campaignDto, Long campaignId, String keyword, Long bidingPrice) {
-        return new CreativeDto(campaignDto, campaignId, null, keyword, bidingPrice, null, null, null, null, false);
+
+        String sBidingPrice = formatToString(bidingPrice);
+
+        return new CreativeDto(campaignDto, campaignId, null, keyword, bidingPrice, sBidingPrice, null, null, null, null, false);
     }
 
-    public static CreativeDto of(CampaignDto campaignDto, Long campaignId, Long id, String keyword, Long bidingPrice, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy, boolean activated) {
-        return new CreativeDto(campaignDto, campaignId, id, keyword, bidingPrice, createdAt, createdBy, modifiedAt, modifiedBy, activated);
+    public static CreativeDto of(CampaignDto campaignDto, Long campaignId, Long id, String keyword, Long bidingPrice, String sBidingPrice, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy, boolean activated) {
+        return new CreativeDto(campaignDto, campaignId, id, keyword, bidingPrice, sBidingPrice, createdAt, createdBy, modifiedAt, modifiedBy, activated);
     }
 
     // Entity -> dto로 변환
     public static CreativeDto from(Creative entity) {
+
+        String sBidingPrice = formatToString(entity.getBidingPrice());
+
         return new CreativeDto(
                 CampaignDto.from(entity.getCampaign()),
                 entity.getCampaign().getId(),
                 entity.getId(),
                 entity.getKeyword(),
                 entity.getBidingPrice(),
+                sBidingPrice,
                 entity.getCreatedAt(),
                 entity.getCreatedBy(),
                 entity.getModifiedAt(),
                 entity.getModifiedBy(),
-				entity.isActivated()
+                entity.isActivated()
         );
     }
 
@@ -49,5 +58,10 @@ public record CreativeDto(
                 keyword,
                 bidingPrice
         );
+    }
+
+    public static String formatToString(Long amount) {
+        DecimalFormat df = new DecimalFormat("###,###");
+        return df.format(amount);
     }
 }

--- a/src/main/java/com/agencyplatformclonecoding/dto/CreativeWithPerformancesDto.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/CreativeWithPerformancesDto.java
@@ -2,6 +2,7 @@ package com.agencyplatformclonecoding.dto;
 
 import com.agencyplatformclonecoding.domain.Creative;
 
+import java.text.DecimalFormat;
 import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -13,6 +14,7 @@ public record CreativeWithPerformancesDto(
         Long id,
         String keyword,
         Long bidingPrice,
+        String sBidingPrice,
         LocalDateTime createdAt,
         String createdBy,
         LocalDateTime modifiedAt,
@@ -21,18 +23,22 @@ public record CreativeWithPerformancesDto(
         boolean activated
 ) {
 
-    public static CreativeWithPerformancesDto of(CampaignDto campaignDto, Long campaignId, Long id, String keyword, Long bidingPrice, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy, Set<PerformanceDto> performanceDtos, boolean activated) {
-        return new CreativeWithPerformancesDto(campaignDto, campaignId, id, keyword, bidingPrice, createdAt, createdBy, modifiedAt, modifiedBy, performanceDtos, activated);
+    public static CreativeWithPerformancesDto of(CampaignDto campaignDto, Long campaignId, Long id, String keyword, Long bidingPrice, String sBidingPrice, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy, Set<PerformanceDto> performanceDtos, boolean activated) {
+        return new CreativeWithPerformancesDto(campaignDto, campaignId, id, keyword, bidingPrice, sBidingPrice, createdAt, createdBy, modifiedAt, modifiedBy, performanceDtos, activated);
     }
 
     // Entity -> dto로 변환
     public static CreativeWithPerformancesDto from(Creative entity) {
+
+        String sBidingPrice = formatToString(entity.getBidingPrice());
+
         return new CreativeWithPerformancesDto(
                 CampaignDto.from(entity.getCampaign()),
                 entity.getCampaign().getId(),
                 entity.getId(),
                 entity.getKeyword(),
                 entity.getBidingPrice(),
+                sBidingPrice,
                 entity.getCreatedAt(),
                 entity.getCreatedBy(),
                 entity.getModifiedAt(),
@@ -40,7 +46,12 @@ public record CreativeWithPerformancesDto(
                 entity.getPerformances().stream()
                         .map(PerformanceDto::from)
                         .collect(Collectors.toCollection(LinkedHashSet::new)),
-				entity.isActivated()
+                entity.isActivated()
         );
+    }
+
+    public static String formatToString(Long amount) {
+        DecimalFormat df = new DecimalFormat("###,###");
+        return df.format(amount);
     }
 }

--- a/src/main/java/com/agencyplatformclonecoding/dto/PerformanceDto.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/PerformanceDto.java
@@ -3,77 +3,110 @@ package com.agencyplatformclonecoding.dto;
 import com.agencyplatformclonecoding.domain.Creative;
 import com.agencyplatformclonecoding.domain.Performance;
 
+import java.text.DecimalFormat;
 import java.time.LocalDate;
 
 public record PerformanceDto(
         CreativeDto creativeDto,
-		Long creativeId,
+        Long creativeId,
         Long id,
         Long view,
+        String sView,
         Long click,
+        String sClick,
         Long conversion,
+        String sConversion,
         Long purchase,
-		Long spend,
-		double CTR,
+        String sPurchase,
+        Long spend,
+        String sSpend,
+        double CTR,
         String sCTR,
-		double CVR,
+        double CVR,
         String sCVR,
-		Long CPA,
-		double ROAS,
+        Long CPA,
+        String sCPA,
+        double ROAS,
         String sROAS,
         LocalDate createdAt
 ) {
 
     public static PerformanceDto of(CreativeDto creativeDto, Long creativeId, Long view, Long click, Long conversion, Long purchase) {
-        return new PerformanceDto(creativeDto, creativeId, null, view, click, conversion, purchase, null, 0, null, 0, null, 0L, 0, null, null);
+
+        String sView = formatToString(view);
+        String sClick = formatToString(click);
+        String sConversion = formatToString(conversion);
+        String sPurchase = formatToString(purchase);
+
+        return new PerformanceDto(creativeDto, creativeId, null, view, sView, click, sClick, conversion, sConversion, purchase, sPurchase, null, null, 0, null, 0, null, 0L, null, 0, null, null);
     }
 
     public static PerformanceDto of(CreativeDto creativeDto, Long creativeId, Long id, Long view, Long click, Long conversion, Long purchase, LocalDate createdAt) {
 
+        String sView = formatToString(view);
+        String sClick = formatToString(click);
+        String sConversion = formatToString(conversion);
+        String sPurchase = formatToString(purchase);
+
         Long spend = creativeDto.bidingPrice() * click;
+        String sSpend = formatToString(spend);
         double CTR = calculateCTR(click, view);
         String sCTR = String.format("%.2f", CTR);
         double CVR = calculateCVR(conversion, click);
         String sCVR = String.format("%.2f", CVR);
         Long CPA = calculateCPA(spend, conversion);
+        String sCPA = formatToString(CPA);
         double ROAS = calculateROAS(purchase, spend);
         String sROAS = String.format("%.2f", ROAS);
 
-		return new PerformanceDto(creativeDto, creativeId, id, view, click, conversion, purchase, spend, CTR, sCTR, CVR, sCVR, CPA, ROAS, sROAS, createdAt);
+        return new PerformanceDto(creativeDto, creativeId, id, view, sView, click, sClick, conversion, sConversion, purchase, sPurchase, spend, sSpend, CTR, sCTR, CVR, sCVR, CPA, sCPA, ROAS, sROAS, createdAt);
     }
 
-	public static PerformanceDto of(CreativeDto creativeDto, Long creativeId, Long id, Long view, Long click, Long conversion, Long purchase, Long spend, double CTR, String sCTR, double CVR, String sCVR, Long CPA, double ROAS, String sROAS, LocalDate createdAt) {
+    public static PerformanceDto of(CreativeDto creativeDto, Long creativeId, Long id, Long view, String sView, Long click, String sClick, Long conversion, String sConversion, Long purchase, String sPurchase, Long spend, String sSpend, double CTR, String sCTR, double CVR, String sCVR, Long CPA, String sCPA, double ROAS, String sROAS, LocalDate createdAt) {
 
-		return new PerformanceDto(creativeDto, creativeId, id, view, click, conversion, purchase, spend, CTR, sCTR, CVR, sCVR, CPA, ROAS, sROAS, createdAt);
+        return new PerformanceDto(creativeDto, creativeId, id, view, sView, click, sClick, conversion, sConversion, purchase, sPurchase, spend, sSpend, CTR, sCTR, CVR, sCVR, CPA, sCPA, ROAS, sROAS, createdAt);
     }
 
     // Entity -> dto로 변환
     public static PerformanceDto from(Performance entity) {
 
-		Long spend = entity.getCreative().getBidingPrice() * entity.getClick();
-        double CTR = calculateCTR(entity.getClick(),entity.getView());
-        String sCTR = String.format("%.2f", CTR*100);
+        String sView = formatToString(entity.getView());
+        String sClick = formatToString(entity.getClick());
+        String sConversion = formatToString(entity.getConversion());
+        String sPurchase = formatToString(entity.getPurchase());
+
+        Long spend = entity.getCreative().getBidingPrice() * entity.getClick();
+        String sSpend = formatToString(spend);
+        double CTR = calculateCTR(entity.getClick(), entity.getView());
+        String sCTR = String.format("%.2f", CTR * 100);
         double CVR = calculateCVR(entity.getConversion(), entity.getClick());
-        String sCVR = String.format("%.2f", CVR*100);
+        String sCVR = String.format("%.2f", CVR * 100);
         Long CPA = calculateCPA(spend, entity.getConversion());
+        String sCPA = formatToString(CPA);
         double ROAS = calculateROAS(entity.getPurchase(), spend);
-        String sROAS = String.format("%.2f", ROAS*100);
+        String sROAS = String.format("%.2f", ROAS * 100);
 
         return new PerformanceDto(
                 CreativeDto.from(entity.getCreative()),
                 entity.getCreative().getId(),
                 entity.getId(),
                 entity.getView(),
+                sView,
                 entity.getClick(),
+                sClick,
                 entity.getConversion(),
-				entity.getPurchase(),
-				spend,
-				CTR,
+                sConversion,
+                entity.getPurchase(),
+                sPurchase,
+                spend,
+                sSpend,
+                CTR,
                 sCTR,
-				CVR,
+                CVR,
                 sCVR,
-				CPA,
-				ROAS,
+                CPA,
+                sCPA,
+                ROAS,
                 sROAS,
                 entity.getCreatedAt()
         );
@@ -83,10 +116,10 @@ public record PerformanceDto(
     public Performance toEntity(Creative creative) {
         return Performance.of(
                 creative,
-				view,
-				click,
-				conversion,
-				purchase
+                view,
+                click,
+                conversion,
+                purchase
         );
     }
 
@@ -100,18 +133,26 @@ public record PerformanceDto(
     public static double calculateCVR(Long conversion, Long click) {
         if (click == 0) {
             return 0;
-        } return (double) conversion / click;
+        }
+        return (double) conversion / click;
     }
 
     public static Long calculateCPA(Long spend, Long conversion) {
         if (conversion == 0) {
             return null;
-        } return spend / conversion;
+        }
+        return spend / conversion;
     }
 
     public static double calculateROAS(Long purchase, Long spend) {
         if (spend == 0) {
             return 0;
-        } return (double) purchase / spend;
+        }
+        return (double) purchase / spend;
+    }
+
+    public static String formatToString(Long amount) {
+        DecimalFormat df = new DecimalFormat("###,###");
+        return df.format(amount);
     }
 }

--- a/src/main/java/com/agencyplatformclonecoding/dto/response/CampaignResponse.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/response/CampaignResponse.java
@@ -11,12 +11,13 @@ public record CampaignResponse(
         LocalDateTime createdAt,
         String name,
         Long budget,
+        String sBudget,
         String clientUserName,
         boolean activated
 ) implements Serializable {
 
-    public static CampaignResponse of(Long id, LocalDateTime createdAt, String name, Long budget, String clientUserName, boolean activated) {
-        return new CampaignResponse(id, createdAt, name, budget, clientUserName, activated);
+    public static CampaignResponse of(Long id, LocalDateTime createdAt, String name, Long budget, String sBudget, String clientUserName, boolean activated) {
+        return new CampaignResponse(id, createdAt, name, budget, sBudget, clientUserName, activated);
     }
 
     public static CampaignResponse from(CampaignDto dto) {
@@ -32,6 +33,7 @@ public record CampaignResponse(
                 dto.createdAt(),
                 dto.name(),
                 dto.budget(),
+                dto.sBudget(),
                 clientUserName,
                 activated
         );

--- a/src/main/java/com/agencyplatformclonecoding/dto/response/CampaignWithCreativesResponse.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/response/CampaignWithCreativesResponse.java
@@ -14,26 +14,28 @@ public record CampaignWithCreativesResponse(
         LocalDateTime createdAt,
         String name,
         Long budget,
+        String sBudget,
         Set<CreativeResponse> creativeResponses,
         boolean activated
 ) implements Serializable {
 
-    public static CampaignWithCreativesResponse of(Long id, LocalDateTime createdAt, String name, Long budget, Set<CreativeResponse> creativeResponses, boolean activated) {
-        return new CampaignWithCreativesResponse(id, createdAt, name, budget, creativeResponses, activated);
+    public static CampaignWithCreativesResponse of(Long id, LocalDateTime createdAt, String name, Long budget, String sbudget, Set<CreativeResponse> creativeResponses, boolean activated) {
+        return new CampaignWithCreativesResponse(id, createdAt, name, budget, sbudget, creativeResponses, activated);
     }
 
     public static CampaignWithCreativesResponse from(CampaignWithCreativesDto dto) {
-		boolean activated = dto.activated();
+        boolean activated = dto.activated();
 
         return new CampaignWithCreativesResponse(
                 dto.id(),
                 dto.createdAt(),
                 dto.name(),
                 dto.budget(),
+                dto.sBudget(),
                 dto.creativeDtos().stream()
                         .map(CreativeResponse::from)
                         .collect(Collectors.toCollection(LinkedHashSet::new)),
-				activated
+                activated
         );
     }
 }

--- a/src/main/java/com/agencyplatformclonecoding/dto/response/CreativeResponse.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/response/CreativeResponse.java
@@ -8,12 +8,13 @@ public record CreativeResponse(
         Long id,
         String keyword,
         Long bidingPrice,
+        String sBidingPrice,
         Long campaignId,
         boolean activated
 ) implements Serializable {
 
-    public static CreativeResponse of(Long id, String keyword, Long bidingPrice, Long campaignId, boolean activated) {
-        return new CreativeResponse(id, keyword, bidingPrice, campaignId, activated);
+    public static CreativeResponse of(Long id, String keyword, Long bidingPrice, String sBidingPrice, Long campaignId, boolean activated) {
+        return new CreativeResponse(id, keyword, bidingPrice, sBidingPrice, campaignId, activated);
     }
 
     public static CreativeResponse from(CreativeDto dto) {
@@ -24,6 +25,7 @@ public record CreativeResponse(
                 dto.id(),
                 dto.keyword(),
                 dto.bidingPrice(),
+                dto.sBidingPrice(),
                 campaignId,
                 activated
         );

--- a/src/main/java/com/agencyplatformclonecoding/dto/response/CreativeWithPerformancesResponse.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/response/CreativeWithPerformancesResponse.java
@@ -12,13 +12,14 @@ public record CreativeWithPerformancesResponse(
         Long id,
         String keyword,
         Long bidingPrice,
+        String sBidingPrice,
         Long campaignId,
-		Set<PerformanceResponse> performanceResponses,
+        Set<PerformanceResponse> performanceResponses,
         boolean activated
 ) implements Serializable {
 
-    public static CreativeWithPerformancesResponse of(Long id, String keyword, Long bidingPrice, Long campaignId, Set<PerformanceResponse> performanceResponses, boolean activated) {
-        return new CreativeWithPerformancesResponse(id, keyword, bidingPrice, campaignId, performanceResponses, activated);
+    public static CreativeWithPerformancesResponse of(Long id, String keyword, Long bidingPrice, String sBidingPrice, Long campaignId, Set<PerformanceResponse> performanceResponses, boolean activated) {
+        return new CreativeWithPerformancesResponse(id, keyword, bidingPrice, sBidingPrice, campaignId, performanceResponses, activated);
     }
 
     public static CreativeWithPerformancesResponse from(CreativeWithPerformancesDto dto) {
@@ -29,10 +30,11 @@ public record CreativeWithPerformancesResponse(
                 dto.id(),
                 dto.keyword(),
                 dto.bidingPrice(),
+                dto.sBidingPrice(),
                 campaignId,
-				dto.performanceDtos().stream()
-						.map(PerformanceResponse::from)
-						.collect(Collectors.toCollection(LinkedHashSet::new)),
+                dto.performanceDtos().stream()
+                        .map(PerformanceResponse::from)
+                        .collect(Collectors.toCollection(LinkedHashSet::new)),
                 activated
         );
     }

--- a/src/main/java/com/agencyplatformclonecoding/dto/response/PerformanceResponse.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/response/PerformanceResponse.java
@@ -8,23 +8,29 @@ import java.time.LocalDate;
 public record PerformanceResponse(
         Long id,
         Long view,
+        String sView,
         Long click,
+        String sClick,
         Long conversion,
+        String sConversion,
         Long purchase,
-		Long spend,
-		double CTR,
-		String sCTR,
-		double CVR,
-		String sCVR,
-		Long CPA,
-		double ROAS,
-		String sROAS,
-		LocalDate createdAt,
-		Long creativeId
+        String sPurchase,
+        Long spend,
+        String sSpend,
+        double CTR,
+        String sCTR,
+        double CVR,
+        String sCVR,
+        Long CPA,
+        String sCPA,
+        double ROAS,
+        String sROAS,
+        LocalDate createdAt,
+        Long creativeId
 ) implements Serializable {
 
-    public static PerformanceResponse of(Long id, Long view, Long click, Long conversion, Long purchase, Long spend, double CTR, String sCTR, double CVR, String sCVR, Long CPA, double ROAS, String sROAS, LocalDate createdAt, Long creativeId) {
-        return new PerformanceResponse(id, view, click, conversion, purchase, spend, CTR, sCTR, CVR, sCVR, CPA, ROAS, sROAS, createdAt, creativeId);
+    public static PerformanceResponse of(Long id, Long view, String sView, Long click, String sClick, Long conversion, String sConversion, Long purchase, String sPurchase, Long spend, String sSpend, double CTR, String sCTR, double CVR, String sCVR, Long CPA, String sCPA, double ROAS, String sROAS, LocalDate createdAt, Long creativeId) {
+        return new PerformanceResponse(id, view, sView, click, sClick, conversion, sConversion, purchase, sPurchase, spend, sSpend, CTR, sCTR, CVR, sCVR, CPA, sCPA, ROAS, sROAS, createdAt, creativeId);
     }
 
     public static PerformanceResponse from(PerformanceDto dto) {
@@ -33,18 +39,24 @@ public record PerformanceResponse(
         return new PerformanceResponse(
                 dto.id(),
                 dto.view(),
+                dto.sView(),
                 dto.click(),
+                dto.sClick(),
                 dto.conversion(),
+                dto.sConversion(),
                 dto.purchase(),
-				dto.spend(),
-				dto.CTR(),
-				dto.sCTR(),
-				dto.CVR(),
-				dto.sCVR(),
-				dto.CPA(),
-				dto.ROAS(),
-				dto.sROAS(),
-				dto.createdAt(),
+                dto.sPurchase(),
+                dto.spend(),
+                dto.sSpend(),
+                dto.CTR(),
+                dto.sCTR(),
+                dto.CVR(),
+                dto.sCVR(),
+                dto.CPA(),
+                dto.sCPA(),
+                dto.ROAS(),
+                dto.sROAS(),
+                dto.createdAt(),
                 creativeId
         );
     }

--- a/src/main/resources/templates/manage/campaign.th.xml
+++ b/src/main/resources/templates/manage/campaign.th.xml
@@ -35,7 +35,7 @@
           <attr sel="#activate-button" th:classappend="${campaign.activated} != true ? 'btn btn-danger active' : 'btn btn-primary active'"/>
           <attr sel="td.id" th:text="${campaign.id}"/>
           <attr sel="td.name" th:text="${campaign.name}"/>
-          <attr sel="td.budget" th:text="${campaign.budget}"/>
+          <attr sel="td.budget" th:text="${campaign.sBudget} + '원'"/>
           <attr sel="#manage-campaign" th:href="'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/form'"/>
           <attr sel="#creative-detail" th:href="'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'"/>
           <attr sel="#delete-campaign-form" th:action="'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/delete'" th:method="post"/>

--- a/src/main/resources/templates/manage/creative.th.xml
+++ b/src/main/resources/templates/manage/creative.th.xml
@@ -39,7 +39,7 @@
           <attr sel="#activate-button" th:classappend="${creative.activated} != true ? 'btn btn-danger active' : 'btn btn-primary active'"/>
           <attr sel="td.id" th:text="${creative.id}" />
           <attr sel="td.keyword" th:text="${creative.keyword}" />
-          <attr sel="td.biding-price" th:text="${creative.bidingPrice}" />
+          <attr sel="td.biding-price" th:text="${creative.sBidingPrice} + '원'" />
           <attr sel="#manage-creative" th:href="'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives/' + ${creative.id} + '/form'" />
           <attr sel="#delete-creative-form" th:action="'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives/' + ${creative.id} + '/delete'" th:method="post" />
           <attr sel="#performance-info" th:href="'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives/' + ${creative.id} + '/performances'"/>

--- a/src/main/resources/templates/manage/performance.th.xml
+++ b/src/main/resources/templates/manage/performance.th.xml
@@ -25,22 +25,38 @@
       <attr sel="#activate-button" th:classappend="${creative.activated} != true ? 'btn btn-danger active' : 'btn btn-primary active'"/>
       <attr sel="td.id" th:text="${creative.id}" />
       <attr sel="td.keyword" th:text="${creative.keyword}" />
-      <attr sel="td.biding-price" th:text="${creative.bidingPrice} + '원'"/>
+      <attr sel="td.biding-price" th:text="${creative.sBidingPrice} + '원'"/>
     </attr>
   </attr>
+
+    <attr sel="#statistics-info">
+        <attr sel="tbody" th:remove="all-but-first">
+          <attr sel="tr[0]" th:each="statistic : ${statstics}">
+            <attr sel="td.view" th:text="${statistic.sView}" />
+            <attr sel="td.click" th:text="${statistic.sClick}" />
+            <attr sel="td.conversion" th:text="${statistic.sConversion}" />
+            <attr sel="td.purchase" th:text="${statistic.sPurchase} + '원'"/>
+            <attr sel="td.spend" th:text="${statistic.sSpend} + '원'" />
+            <attr sel="td.CTR" th:text="${statistic.sCTR} + '%'" />
+            <attr sel="td.CVR" th:text="${statistic.sCVR} + '%'"/>
+            <attr sel="td.CPA" th:text="${statistic.CPA} + '원'" />
+            <attr sel="td.ROAS" th:text="${statistic.sROAS} + '%'" />
+          </attr>
+        </attr>
+      </attr>
 
   <attr sel="#performance-table">
       <attr sel="tbody" th:remove="all-but-first">
         <attr sel="tr[0]" th:each="performance : ${performances}">
           <attr sel="td.date" th:text="${performance.createdAt}" />
-          <attr sel="td.view" th:text="${performance.view}" />
-          <attr sel="td.click" th:text="${performance.click}" />
-          <attr sel="td.conversion" th:text="${performance.conversion}" />
-          <attr sel="td.purchase" th:text="${performance.purchase} + '원'"/>
-          <attr sel="td.spend" th:text="${performance.spend} + '원'" />
+          <attr sel="td.view" th:text="${performance.sView}" />
+          <attr sel="td.click" th:text="${performance.sClick}" />
+          <attr sel="td.conversion" th:text="${performance.sConversion}" />
+          <attr sel="td.purchase" th:text="${performance.sPurchase} + '원'"/>
+          <attr sel="td.spend" th:text="${performance.sSpend} + '원'" />
           <attr sel="td.CTR" th:text="${performance.sCTR} + '%'" />
           <attr sel="td.CVR" th:text="${performance.sCVR} + '%'"/>
-          <attr sel="td.CPA" th:text="${performance.CPA} + '원'" />
+          <attr sel="td.CPA" th:text="${performance.sCPA} + '원'" />
           <attr sel="td.ROAS" th:text="${performance.sROAS} + '%'" />
         </attr>
       </attr>


### PR DESCRIPTION
현재 숫자에 자릿수 구분용 콤마가 찍혀 있지 않아 지표의 가독성이 떨어진다.
다만 콤마를 찍을 경우 자료형이 Long이 아닌 String 으로 변환을 해줘야 하기 때문에
실제 지표 Long -> String 변환 -> 출력 처리를 해야 할 것으로 보인다.
(Response에서 처리하는 것이 좋아 보임)

* [x] Dto / Response 수정
  * [x] 캠페인
  * [x] 소재
  * [x] 실적

This closes #88 