### PR TITLE
광고 관리 페이지 (소재 리스트) 수정 및 통계 기능 구현

### DIFF
--- a/src/main/java/com/agencyplatformclonecoding/controller/CreativeController.java
+++ b/src/main/java/com/agencyplatformclonecoding/controller/CreativeController.java
@@ -18,7 +18,10 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @RequestMapping(value = "/manage/{clientId}/campaigns/{campaignId}/creatives")
@@ -129,7 +132,8 @@ public class CreativeController {
         CampaignWithCreativesResponse campaignWithCreativesResponse = CampaignWithCreativesResponse.from(campaignService.getCampaignWithCreatives(campaignId));
         ClientUserWithCampaignsResponse clientUserWithCampaignsResponse = ClientUserWithCampaignsResponse.from(manageService.getClientUserWithCampaigns(clientId));
         Page<PerformanceResponse> performances = performanceService.searchPerformances(pageable, statisticsType, creativeId, campaignId, clientId).map(PerformanceResponse::from);
-        PerformanceStatisticsResponse statistic = PerformanceStatisticsResponse.from(statisticsService.totalPerformanceStatistics(statisticsType, creativeId));
+        Set<PerformanceStatisticsResponse> statistics = statisticsService.totalPerformanceStatistics(statisticsType, creativeId)
+                .stream().map(PerformanceStatisticsResponse::from).collect(Collectors.toCollection(LinkedHashSet::new));
         List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), performances.getTotalPages());
 
         map.addAttribute("clientUser", clientUserWithCampaignsResponse);
@@ -137,7 +141,7 @@ public class CreativeController {
         map.addAttribute("creative", creativeWithPerformancesResponse);
         map.addAttribute("performances", performances);
         map.addAttribute("paginationBarNumbers", barNumbers);
-        map.addAttribute("statistic", statistic);
+        map.addAttribute("statistics", statistics);
         map.addAttribute("totalCount", performanceService.getPerformanceCount());
 
         return "manage/performance";

--- a/src/main/java/com/agencyplatformclonecoding/dto/PerformanceStatisticsDto.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/PerformanceStatisticsDto.java
@@ -7,6 +7,9 @@ import java.text.DecimalFormat;
 @Getter
 public class PerformanceStatisticsDto {
     Long creativeId;
+    String keyword;
+    Long bidingPrice;
+    String sBidingPrice;
     Long view;
     String sView;
     Long click;
@@ -25,6 +28,8 @@ public class PerformanceStatisticsDto {
     String sCPA;
     double ROAS;
     String sROAS;
+    boolean activated;
+    boolean deleted;
 
     public PerformanceStatisticsDto() {
     }
@@ -75,29 +80,93 @@ public class PerformanceStatisticsDto {
         return new PerformanceStatisticsDto(creativeId, view, sView, click, sClick, conversion, sConversion, purchase, sPurchase, spend, sSpend, CTR, sCTR, CVR, sCVR, CPA, sCPA, ROAS, sROAS);
     }
 
+    public void setCreativeIndicator(Long spend, Long view, Long click, Long conversion, Long purchase) {
+
+        String sBidingPrice = formatToString(bidingPrice);
+        String sSpend = formatToString(spend);
+        String sView = formatToString(view);
+        String sClick = formatToString(click);
+        String sConversion = formatToString(conversion);
+        String sPurchase = formatToString(purchase);
+        double CTR = calculateCTR(click, view);
+        String sCTR = String.format("%.2f", CTR * 100);
+        double CVR = calculateCVR(conversion, click);
+        String sCVR = String.format("%.2f", CVR * 100);
+        Long CPA = calculateCPA(spend, conversion);
+        String sCPA = formatToString(CPA);
+        double ROAS = calculateROAS(purchase, spend);
+        String sROAS = String.format("%.2f", ROAS * 100);
+
+        this.sSpend = sSpend;
+        this.sBidingPrice = sBidingPrice;
+        this.sView = sView;
+        this.sClick = sClick;
+        this.sConversion = sConversion;
+        this.sPurchase = sPurchase;
+        this.CTR = CTR;
+        this.sCTR = sCTR;
+        this.CVR = CVR;
+        this.sCVR = sCVR;
+        this.CPA = CPA;
+        this.sCPA = sCPA;
+        this.ROAS = ROAS;
+        this.sROAS =sROAS;
+    }
+
+    public void setCampaignTotalIndicator(Long spend, Long view, Long click, Long conversion, Long purchase) {
+
+        String sSpend = formatToString(spend);
+        String sView = formatToString(view);
+        String sClick = formatToString(click);
+        String sConversion = formatToString(conversion);
+        String sPurchase = formatToString(purchase);
+        double CTR = calculateCTR(click, view);
+        String sCTR = String.format("%.2f", CTR * 100);
+        double CVR = calculateCVR(conversion, click);
+        String sCVR = String.format("%.2f", CVR * 100);
+        Long CPA = calculateCPA(spend, conversion);
+        String sCPA = formatToString(CPA);
+        double ROAS = calculateROAS(purchase, spend);
+        String sROAS = String.format("%.2f", ROAS * 100);
+
+        this.sSpend = sSpend;
+        this.sView = sView;
+        this.sClick = sClick;
+        this.sConversion = sConversion;
+        this.sPurchase = sPurchase;
+        this.CTR = CTR;
+        this.sCTR = sCTR;
+        this.CVR = CVR;
+        this.sCVR = sCVR;
+        this.CPA = CPA;
+        this.sCPA = sCPA;
+        this.ROAS = ROAS;
+        this.sROAS =sROAS;
+    }
+
     public static double calculateCTR(Long click, Long view) {
-        if (view == 0) {
+        if (view == 0 || view == null) {
             return 0;
         }
         return (double) click / view;
     }
 
     public static double calculateCVR(Long conversion, Long click) {
-        if (click == 0) {
+        if (click == 0 || click == null) {
             return 0;
         }
         return (double) conversion / click;
     }
 
     public static Long calculateCPA(Long spend, Long conversion) {
-        if (conversion == 0) {
+        if (conversion == 0 || conversion == null) {
             return null;
         }
         return spend / conversion;
     }
 
     public static double calculateROAS(Long purchase, Long spend) {
-        if (spend == 0) {
+        if (spend == 0 || spend == null) {
             return 0;
         }
         return (double) purchase / spend;

--- a/src/main/java/com/agencyplatformclonecoding/dto/response/PerformanceStatisticsResponse.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/response/PerformanceStatisticsResponse.java
@@ -8,6 +8,9 @@ import java.time.LocalDate;
 
 public record PerformanceStatisticsResponse(
         Long creativeId,
+        String keyword,
+        Long bidingPrice,
+        String sBidingPrice,
         Long view,
         String sView,
         Long click,
@@ -25,18 +28,23 @@ public record PerformanceStatisticsResponse(
         Long CPA,
         String sCPA,
         double ROAS,
-        String sROAS
+        String sROAS,
+        boolean activated,
+        boolean deleted
 
 ) implements Serializable {
 
-    public static PerformanceStatisticsResponse of(Long creativeId, Long view, String sView, Long click, String sClick, Long conversion, String sConversion, Long purchase, String sPurchase, Long spend, String sSpend, double CTR, String sCTR, double CVR, String sCVR, Long CPA, String sCPA, double ROAS, String sROAS) {
-        return new PerformanceStatisticsResponse(creativeId, view, sView, click, sClick, conversion, sConversion, purchase, sPurchase, spend, sSpend, CTR, sCTR, CVR, sCVR, CPA, sCPA, ROAS, sROAS);
+    public static PerformanceStatisticsResponse of(Long creativeId, String keyword, Long bidingPrice, String sBidingPrice, Long view, String sView, Long click, String sClick, Long conversion, String sConversion, Long purchase, String sPurchase, Long spend, String sSpend, double CTR, String sCTR, double CVR, String sCVR, Long CPA, String sCPA, double ROAS, String sROAS, boolean activated, boolean deleted) {
+        return new PerformanceStatisticsResponse(creativeId, keyword, bidingPrice, sBidingPrice, view, sView, click, sClick, conversion, sConversion, purchase, sPurchase, spend, sSpend, CTR, sCTR, CVR, sCVR, CPA, sCPA, ROAS, sROAS, activated, deleted);
     }
 
     public static PerformanceStatisticsResponse from(PerformanceStatisticsDto dto) {
 
         return new PerformanceStatisticsResponse(
                 dto.getCreativeId(),
+                dto.getKeyword(),
+                dto.getBidingPrice(),
+                dto.getSBidingPrice(),
                 dto.getView(),
                 dto.getSView(),
                 dto.getClick(),
@@ -54,7 +62,9 @@ public record PerformanceStatisticsResponse(
                 dto.getCPA(),
                 dto.getSCPA(),
                 dto.getROAS(),
-                dto.getSROAS()
+                dto.getSROAS(),
+                dto.isActivated(),
+                dto.isDeleted()
         );
     }
 }

--- a/src/main/java/com/agencyplatformclonecoding/service/CreativeService.java
+++ b/src/main/java/com/agencyplatformclonecoding/service/CreativeService.java
@@ -19,8 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityNotFoundException;
 
-import static com.agencyplatformclonecoding.domain.QCampaign.campaign;
-
 @Slf4j
 @RequiredArgsConstructor
 @Transactional

--- a/src/main/java/com/agencyplatformclonecoding/service/StatisticsService.java
+++ b/src/main/java/com/agencyplatformclonecoding/service/StatisticsService.java
@@ -1,17 +1,10 @@
 package com.agencyplatformclonecoding.service;
 
-import com.agencyplatformclonecoding.domain.constrant.SearchType;
 import com.agencyplatformclonecoding.domain.constrant.StatisticsType;
-import com.agencyplatformclonecoding.dto.AgentDto;
-import com.agencyplatformclonecoding.dto.PerformanceDto;
 import com.agencyplatformclonecoding.dto.PerformanceStatisticsDto;
-import com.agencyplatformclonecoding.exception.AdPlatformException;
-import com.agencyplatformclonecoding.exception.ErrorCode;
 import com.agencyplatformclonecoding.repository.QueryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,7 +22,7 @@ public class StatisticsService {
 
     // List 타입 반환
     @Transactional(readOnly = true)
-    public PerformanceStatisticsDto totalPerformanceStatistics(StatisticsType statisticsType, Long creativeId) {
+    public List<PerformanceStatisticsDto> totalPerformanceStatistics(StatisticsType statisticsType, Long creativeId) {
 
         LocalDate lastDate = LocalDate.parse(LocalDate.now().minusDays(1)
                 .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
@@ -37,12 +30,51 @@ public class StatisticsService {
         LocalDate startDateBeforeThirtyDays = lastDate.minusDays(30);
 
         if (statisticsType == null) {
-            return queryRepository.findByCreative_IdAndStatisticsDefault(creativeId, startDateBeforeThirtyDays, lastDate).get(0);
+            return queryRepository.findByCreative_IdAndStatisticsDefault(creativeId, startDateBeforeThirtyDays, lastDate);
         }
 
         return switch (statisticsType) {
-            case BEFORE_WEEK -> queryRepository.findByCreative_IdAndStatisticsDefault(creativeId, startDateBeforeSevenDays, lastDate).get(0);
-            case BEFORE_MONTH -> queryRepository.findByCreative_IdAndStatisticsDefault(creativeId, startDateBeforeThirtyDays, lastDate).get(0);
+            case BEFORE_WEEK -> queryRepository.findByCreative_IdAndStatisticsDefault(creativeId, startDateBeforeSevenDays, lastDate);
+            case BEFORE_MONTH -> queryRepository.findByCreative_IdAndStatisticsDefault(creativeId, startDateBeforeThirtyDays, lastDate);
+            case BEFORE_CUSTOM -> null;
+        };
+    }
+
+    // List 타입 반환
+    @Transactional(readOnly = true)
+    public List<PerformanceStatisticsDto> creativesWithPerformanceStatistics(StatisticsType statisticsType, Long campaignId) {
+
+        LocalDate lastDate = LocalDate.parse(LocalDate.now().minusDays(1)
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        LocalDate startDateBeforeSevenDays = lastDate.minusDays(6);
+        LocalDate startDateBeforeThirtyDays = lastDate.minusDays(30);
+
+        if (statisticsType == null) {
+            return queryRepository.findByCampaign_IdAndStatisticsDefault(campaignId, startDateBeforeThirtyDays, lastDate);
+        }
+
+        return switch (statisticsType) {
+            case BEFORE_WEEK -> queryRepository.findByCampaign_IdAndStatisticsDefault(campaignId, startDateBeforeSevenDays, lastDate);
+            case BEFORE_MONTH -> queryRepository.findByCampaign_IdAndStatisticsDefault(campaignId, startDateBeforeThirtyDays, lastDate);
+            case BEFORE_CUSTOM -> null;
+        };
+    }
+
+    @Transactional(readOnly = true)
+    public List<PerformanceStatisticsDto> totalCreativesPerformanceStatistics(StatisticsType statisticsType, Long campaignId) {
+
+        LocalDate lastDate = LocalDate.parse(LocalDate.now().minusDays(1)
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        LocalDate startDateBeforeSevenDays = lastDate.minusDays(6);
+        LocalDate startDateBeforeThirtyDays = lastDate.minusDays(30);
+
+        if (statisticsType == null) {
+            return queryRepository.findByCampaign_IdAndTotalStatisticsDefault(campaignId, startDateBeforeThirtyDays, lastDate);
+        }
+
+        return switch (statisticsType) {
+            case BEFORE_WEEK -> queryRepository.findByCampaign_IdAndTotalStatisticsDefault(campaignId, startDateBeforeSevenDays, lastDate);
+            case BEFORE_MONTH -> queryRepository.findByCampaign_IdAndTotalStatisticsDefault(campaignId, startDateBeforeThirtyDays, lastDate);
             case BEFORE_CUSTOM -> null;
         };
     }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -160,11 +160,17 @@ insert into campaign (client_id, created_at, created_by, modified_at, modified_b
 
 -- 소재 관련 (5개)
 insert into creative (campaign_id, created_at, created_by, modified_at, modified_by, biding_price, keyword, activated, deleted) values
-(1, '2022-07-13 01:32:28', 'Karoline', '2021-10-26 02:46:03', 'Karoline', 7224, 'Automation', true, false),
-(1, '2022-07-10 04:40:02', 'Ashien', '2022-07-08 09:18:39', 'Ashien', 4503, 'Criminal Investigations', true, false),
-(1, '2021-11-26 01:47:21', 'Flossie', '2022-01-29 02:01:15', 'Flossie', 5463, 'AVEVA PDMS', true, false),
-(1, '2022-06-10 22:12:32', 'Tracey', '2022-07-01 08:11:24', 'Tracey', 8190, 'Switches', true, false),
-(1, '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', 5423, 'Air Freight', true, false);
+(1, '2022-07-13 01:32:28', 'Karoline', '2021-10-26 02:46:03', 'Karoline', 7224, '강남핸드폰매장', true, false),
+(1, '2022-07-10 04:40:02', 'Ashien', '2022-07-08 09:18:39', 'Ashien', 4503, '서울핸드폰매장', true, false),
+(1, '2021-11-26 01:47:21', 'Flossie', '2022-01-29 02:01:15', 'Flossie', 5463, '핸드폰매장추천', false, false),
+(1, '2022-06-10 22:12:32', 'Tracey', '2022-07-01 08:11:24', 'Tracey', 8190, '핸드폰중고거래', false, false),
+(1, '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', 5423, '핸드폰중고판매', false, false),
+(1, '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', 5423, '중고핸드폰판매', false, false),
+(1, '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', 5423, '핸드폰저렴하게', false, false),
+(1, '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', 5423, '핸드폰견적', false, false),
+(1, '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', 5423, '강남핸드폰견적', false, false),
+(1, '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', 5423, '서울핸드폰견적', false, false),
+(1, '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', 5423, '저가형핸드폰', false, false);
 
 -- 소재 실적 관련 (1개 소재, 31일치)
 insert into performance (creative_id, created_at, view, click, conversion, purchase, spend) values
@@ -198,4 +204,35 @@ insert into performance (creative_id, created_at, view, click, conversion, purch
 (1, DATE_SUB(now(), INTERVAL 4 DAY), 152, 51, 26, 8790000, 368424),
 (1, DATE_SUB(now(), INTERVAL 3 DAY), 604, 71, 16, 9620000, 512904),
 (1, DATE_SUB(now(), INTERVAL 2 DAY), 450, 73, 8, 1249000, 527352),
-(1, DATE_SUB(now(), INTERVAL 1 DAY), 535, 97, 34, 7844000, 700728);
+(1, DATE_SUB(now(), INTERVAL 1 DAY), 535, 97, 34, 7844000, 700728),
+(2, DATE_SUB(now(), INTERVAL 31 DAY), 234, 35, 12, 2606000, 545640),
+(2, DATE_SUB(now(), INTERVAL 30 DAY), 666, 46, 14, 1128000, 434534),
+(2, DATE_SUB(now(), INTERVAL 29 DAY), 554, 23, 15, 4361000, 565232),
+(2, DATE_SUB(now(), INTERVAL 28 DAY), 662, 56, 24, 6456000, 365344),
+(2, DATE_SUB(now(), INTERVAL 27 DAY), 552, 39, 23, 7621000, 343646),
+(2, DATE_SUB(now(), INTERVAL 26 DAY), 17, 49, 5, 7551000, 386536),
+(2, DATE_SUB(now(), INTERVAL 25 DAY), 421, 74, 10, 5834000, 487456),
+(2, DATE_SUB(now(), INTERVAL 24 DAY), 123, 61, 34, 3435000, 492344),
+(2, DATE_SUB(now(), INTERVAL 23 DAY), 155, 16, 12, 6453000, 645348),
+(2, DATE_SUB(now(), INTERVAL 22 DAY), 22, 23, 12, 8605000, 436546),
+(2, DATE_SUB(now(), INTERVAL 21 DAY), 68, 56, 33, 4325000, 552349),
+(2, DATE_SUB(now(), INTERVAL 20 DAY), 43, 34, 20, 3942000, 423420),
+(2, DATE_SUB(now(), INTERVAL 19 DAY), 93, 24, 43, 5823000, 295450),
+(2, DATE_SUB(now(), INTERVAL 18 DAY), 96, 43, 22, 6033000, 666238),
+(2, DATE_SUB(now(), INTERVAL 17 DAY), 68, 65, 27, 1234000, 464530),
+(2, DATE_SUB(now(), INTERVAL 16 DAY), 35, 24, 12, 4662000, 324538),
+(2, DATE_SUB(now(), INTERVAL 15 DAY), 15, 35, 15, 3645000, 294540),
+(2, DATE_SUB(now(), INTERVAL 14 DAY), 99, 65, 30, 3240000, 446530),
+(2, DATE_SUB(now(), INTERVAL 13 DAY), 64, 92, 35, 7772000, 545466),
+(2, DATE_SUB(now(), INTERVAL 12 DAY), 33, 51, 12, 5734000, 535234),
+(2, DATE_SUB(now(), INTERVAL 11 DAY), 51, 56, 28, 7452000, 592348),
+(2, DATE_SUB(now(), INTERVAL 10 DAY), 54, 45, 21, 6143000, 454530),
+(2, DATE_SUB(now(), INTERVAL 9 DAY), 82, 34, 12, 3645000, 365346),
+(2, DATE_SUB(now(), INTERVAL 8 DAY), 91, 56, 10, 1663000, 592434),
+(2, DATE_SUB(now(), INTERVAL 7 DAY), 52, 25, 12, 1225000, 395342),
+(2, DATE_SUB(now(), INTERVAL 6 DAY), 59, 34, 11, 5104000, 332340),
+(2, DATE_SUB(now(), INTERVAL 5 DAY), 47, 56, 21, 4235000, 495346),
+(2, DATE_SUB(now(), INTERVAL 4 DAY), 12, 23, 14, 7563000, 293534),
+(2, DATE_SUB(now(), INTERVAL 3 DAY), 64, 41, 16, 8534000, 483424),
+(2, DATE_SUB(now(), INTERVAL 2 DAY), 45, 54, 8, 945000, 465632),
+(2, DATE_SUB(now(), INTERVAL 1 DAY), 55, 55, 34, 5653000, 634428);

--- a/src/main/resources/static/css/layout.css
+++ b/src/main/resources/static/css/layout.css
@@ -79,7 +79,7 @@ th, td {
 
 .stats-btn {
     width: fit-content;
-    margin-left: 10px;
+    margin-right: 10px;
 }
 
 .row.right {

--- a/src/main/resources/templates/manage/campaign.th.xml
+++ b/src/main/resources/templates/manage/campaign.th.xml
@@ -20,7 +20,7 @@
       <attr sel="thead/tr">
         <attr sel="th.activate-status/a" th:text="'상태'" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(
       page=${campaigns.number},
-      sort='status' + (*{sort.getOrderFor('status')} != null ? (*{sort.getOrderFor('status').direction.name} != 'DESC' ? ',desc' : '') : '')
+      sort='activated' + (*{sort.getOrderFor('activated')} != null ? (*{sort.getOrderFor('activated').direction.name} != 'DESC' ? ',desc' : '') : '')
   )}"/>
         <attr sel="th.budget/a" th:text="'예산'" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(
       page=${campaigns.number},

--- a/src/main/resources/templates/manage/creative.html
+++ b/src/main/resources/templates/manage/creative.html
@@ -69,10 +69,12 @@
   </div>
 
   <div class="container">
-    <nav style="--bs-breadcrumb-divider: url(&#34;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Cpath d='M2.5 0L1 1.5 3.5 4 1 6.5 2.5 8l4-4-4-4z' fill='%236c757d'/%3E%3C/svg%3E&#34;);" aria-label="breadcrumb">
+    <nav
+        style="--bs-breadcrumb-divider: url(&#34;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Cpath d='M2.5 0L1 1.5 3.5 4 1 6.5 2.5 8l4-4-4-4z' fill='%236c757d'/%3E%3C/svg%3E&#34;);"
+        aria-label="breadcrumb">
       <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="/manage">광고 관리</a></li>
-    	<li class="to-campaign breadcrumb-item"><a>캠페인 관리</a></li>
+        <li class="to-campaign breadcrumb-item"><a>캠페인 관리</a></li>
         <li class="breadcrumb-item active" aria-current="page">소재 관리</li>
       </ol>
     </nav>
@@ -82,24 +84,86 @@
 
     <div class="row right">
       <div class="create-btn d-grid gap-2 justify-content-md">
+        <a class="stats-btn btn btn-primary" role="button" id="statistics_type_week">최근 7일간 통계</a>
+        <a class="stats-btn btn btn-primary" role="button" id="statistics_type_month">최근 30일간 통계</a>
         <a class="btn btn-primary me-md-2" role="button" id="create-creative">소재 생성</a>
       </div>
     </div>
 
     <div class="row">
-      <table class="table" id="client-info">
+      <table class="table" id="campaign-statistics-info">
         <thead>
         <tr>
-          <th class="user-id col-xs-2"><a>광고주 ID</a></th>
-          <th class="nickname col-xs-2"><a>광고주명</a></th>
-          <th class="category col-xs-2"><a>업종</a></th>
+          <th class="view" style="width: 75px;"><a>총 노출수</a></th>
+          <th class="click" style="width: 75px;"><a>총 클릭수</a></th>
+          <th class="conversion" style="width: 75px;"><a>총 전환수</a></th>
+          <th class="purchase" style="width: 150px;"><a>총 구매액</a></th>
+          <th class="spend" style="width: 125px;"><a>총 소진액</a></th>
+          <th class="CTR" style="width: 75px;"><a>클릭률</a></th>
+          <th class="CVR" style="width: 75px;"><a>전환률</a></th>
+          <th class="CPA" style="width: 100px;"><a>CPA</a></th>
+          <th class="ROAS" style="width: 100px;"><a>ROAS</a></th>
         </tr>
         </thead>
         <tbody>
         <tr>
-          <td class="user-id"><a>client1</a></td>
-          <td class="nickname">코코볼자동차</td>
-          <td class="category">자동차</td>
+          <td class="view"><a>1000</a></td>
+          <td class="click"><a>100</a></td>
+          <td class="conversion"><a>10</a></td>
+          <td class="purchase"><a>100000</a></td>
+          <td class="spend"><a>20000</a></td>
+          <td class="CTR"><a>0.1</a></td>
+          <td class="CVR"><a>0.1</a></td>
+          <td class="CPA"><a>2000</a></td>
+          <td class="ROAS"><a>500</a></td>
+        </tr>
+        </tbody>
+      </table>
+      <table class="table" id="statistics-table">
+        <thead>
+        <tr>
+          <th class="id"><a>ID</a></th>
+          <th class="keyword" style="width: 150px;"><a>키워드</a></th>
+          <th class="biding-price" style="width: 100px;"><a>입찰가</a></th>
+          <th class="view" style="width: 75px;"><a>노출수</a></th>
+          <th class="click" style="width: 75px;"><a>클릭수</a></th>
+          <th class="conversion" style="width: 75px;"><a>전환수</a></th>
+          <th class="purchase" style="width: 150px;"><a>구매액</a></th>
+          <th class="spend" style="width: 125px;"><a>소진액</a></th>
+          <th class="CTR" style="width: 75px;"><a>클릭률</a></th>
+          <th class="CVR" style="width: 75px;"><a>전환률</a></th>
+          <th class="CPA" style="width: 100px;"><a>CPA</a></th>
+          <th class="ROAS" style="width: 100px;"><a>ROAS</a></th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <td class="id">1</td>
+          <td class="keyword">코코볼추천</td>
+          <td class="biding-price">10000</td>
+          <td class="view"><a>1000</a></td>
+          <td class="click"><a>100</a></td>
+          <td class="conversion"><a>10</a></td>
+          <td class="purchase"><a>100000</a></td>
+          <td class="spend"><a>20000</a></td>
+          <td class="CTR"><a>0.1</a></td>
+          <td class="CVR"><a>0.1</a></td>
+          <td class="CPA"><a>2000</a></td>
+          <td class="ROAS"><a>500</a></td>
+        </tr>
+        <tr>
+          <td class="date">2022-08-02</td>
+          <td class="view"><a>1000</a></td>
+          <td class="click"><a>100</a></td>
+          <td class="conversion"><a>10</a></td>
+          <td class="purchase"><a>100000</a></td>
+        </tr>
+        <tr>
+          <td class="date">2022-08-01</td>
+          <td class="view"><a>1000</a></td>
+          <td class="click"><a>100</a></td>
+          <td class="conversion"><a>10</a></td>
+          <td class="purchase"><a>100000</a></td>
         </tr>
         </tbody>
       </table>

--- a/src/main/resources/templates/manage/creative.th.xml
+++ b/src/main/resources/templates/manage/creative.th.xml
@@ -12,19 +12,30 @@
 
   <attr sel="#create-creative" th:href="'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives/form'" />
 
-  <attr sel="#client-info">
-    <attr sel="tbody" th:remove="all-but-first">
-      <attr sel="td.user-id" th:text="${clientUser.userId}" />
-      <attr sel="td.nickname" th:text="${clientUser.nickname}" />
-      <attr sel="td.category" th:text="${clientUser.categoryName}"/>
-    </attr>
-  </attr>
+  <attr sel="#statistics_type_week" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(statisticsType=BEFORE_WEEK)}" th:method="get" />
+  <attr sel="#statistics_type_month" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(statisticsType=BEFORE_MONTH)}" th:method="get" />
+
+    <attr sel="#campaign-statistics-info">
+        <attr sel="tbody" th:remove="all-but-first">
+          <attr sel="tr[0]" th:each="totalCreativeStatistic : ${totalCreativeStatistics}">
+            <attr sel="td.view" th:text="${totalCreativeStatistic.sView}" />
+            <attr sel="td.click" th:text="${totalCreativeStatistic.sClick}" />
+            <attr sel="td.conversion" th:text="${totalCreativeStatistic.sConversion}" />
+            <attr sel="td.purchase" th:text="${totalCreativeStatistic.sPurchase} + '원'"/>
+            <attr sel="td.spend" th:text="${totalCreativeStatistic.sSpend} + '원'" />
+            <attr sel="td.CTR" th:text="${totalCreativeStatistic.sCTR} + '%'" />
+            <attr sel="td.CVR" th:text="${totalCreativeStatistic.sCVR} + '%'"/>
+            <attr sel="td.CPA" th:text="${totalCreativeStatistic.sCPA} + '원'" />
+            <attr sel="td.ROAS" th:text="${totalCreativeStatistic.sROAS} + '%'" />
+          </attr>
+        </attr>
+      </attr>
 
     <attr sel="#creative-table">
       <attr sel="thead/tr">
         <attr sel="th.activate-status/a" th:text="'상태'" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(
       page=${creatives.number},
-      sort='status' + (*{sort.getOrderFor('status')} != null ? (*{sort.getOrderFor('status').direction.name} != 'DESC' ? ',desc' : '') : '')
+      sort='activated' + (*{sort.getOrderFor('activated')} != null ? (*{sort.getOrderFor('activated').direction.name} != 'DESC' ? ',desc' : '') : '')
   )}"/>
         <attr sel="th.biding-price/a" th:text="'입찰가'" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(
       page=${creatives.number},
@@ -46,6 +57,25 @@
         </attr>
       </attr>
     </attr>
+
+    <attr sel="#statistics-table">
+        <attr sel="tbody" th:remove="all-but-first">
+          <attr sel="tr[0]" th:each="creativeStatistic : ${creativeStatistics}">
+            <attr sel="td.id" th:text="${creativeStatistic.creativeId}" />
+            <attr sel="td.keyword" th:text="${creativeStatistic.keyword}" />
+            <attr sel="td.biding-price" th:text="${creativeStatistic.sBidingPrice} + '원'"/>
+            <attr sel="td.view" th:text="${creativeStatistic.sView}" />
+            <attr sel="td.click" th:text="${creativeStatistic.sClick}" />
+            <attr sel="td.conversion" th:text="${creativeStatistic.sConversion}" />
+            <attr sel="td.purchase" th:text="${creativeStatistic.sPurchase} + '원'"/>
+            <attr sel="td.spend" th:text="${creativeStatistic.sSpend} + '원'" />
+            <attr sel="td.CTR" th:text="${creativeStatistic.sCTR} + '%'" />
+            <attr sel="td.CVR" th:text="${creativeStatistic.sCVR} + '%'"/>
+            <attr sel="td.CPA" th:text="${creativeStatistic.sCPA} + '원'" />
+            <attr sel="td.ROAS" th:text="${creativeStatistic.sROAS} + '%'" />
+          </attr>
+        </attr>
+      </attr>
 
     <attr sel="#pagination">
       <attr sel="li[0]/a"

--- a/src/main/resources/templates/manage/performance.th.xml
+++ b/src/main/resources/templates/manage/performance.th.xml
@@ -26,6 +26,7 @@
 
     <attr sel="#statistics-info">
         <attr sel="tbody" th:remove="all-but-first">
+            <attr sel="tr[0]" th:each="statistic : ${statistics}">
             <attr sel="td.view" th:text="${statistic.sView}" />
             <attr sel="td.click" th:text="${statistic.sClick}" />
             <attr sel="td.conversion" th:text="${statistic.sConversion}" />


### PR DESCRIPTION
소재와 연결된 실적들에 대해 통계 기능이 구현되었으므로,
캠페인 페이지 (소재 리스트 및 관리 페이지)에서 소재를 모아놓은 캠페인에 대한 통계 기능을 제공할 수 있도록 수정한다.

* [x] 통계 쿼리 작성 및 테스트 -> QueryDSL로 변환
* [x] 일일 통계 기능 구현
* [x] 최근 1주일 간의 통계 보기 기능 구현
* [x] 최근 30일 간의 통계 보기 기능 구현

This closes #108 