### PR TITLE
광고 관리 페이지 (캠페인 리스트) 수정 및 통계 기능 구현

### DIFF
--- a/src/main/java/com/agencyplatformclonecoding/controller/CampaignController.java
+++ b/src/main/java/com/agencyplatformclonecoding/controller/CampaignController.java
@@ -96,7 +96,7 @@ public class CampaignController {
     public String creatives(
             @PathVariable("clientId") String clientId,
             @PathVariable Long campaignId,
-            @PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @PageableDefault(size = 5, sort = "activated", direction = Sort.Direction.DESC) Pageable pageable,
             @RequestParam(required = false) StatisticsType statisticsType,
             ModelMap map
     ) {

--- a/src/main/java/com/agencyplatformclonecoding/dto/PerformanceStatisticsDto.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/PerformanceStatisticsDto.java
@@ -6,8 +6,14 @@ import java.text.DecimalFormat;
 
 @Getter
 public class PerformanceStatisticsDto {
+    String clientId;
+    Long campaignId;
     Long creativeId;
+    String username;
+    String name;
     String keyword;
+    Long budget;
+    String sBudget;
     Long bidingPrice;
     String sBidingPrice;
     Long view;
@@ -32,52 +38,6 @@ public class PerformanceStatisticsDto {
     boolean deleted;
 
     public PerformanceStatisticsDto() {
-    }
-
-    private PerformanceStatisticsDto(Long creativeId, Long view, String sView, Long click, String sClick, Long conversion, String sConversion, Long purchase, String sPurchase, Long spend, String sSpend, double CTR, String sCTR, double CVR, String sCVR, Long CPA, String sCPA, double ROAS, String sROAS) {
-        this.creativeId = creativeId;
-        this.view = view;
-        this.sView = sView;
-        this.click = click;
-        this.sClick = sClick;
-        this.conversion = conversion;
-        this.sConversion = sConversion;
-        this.purchase = purchase;
-        this.sPurchase = sPurchase;
-        this.spend = spend;
-        this.sSpend = sSpend;
-        this.CTR = CTR;
-        this.sCTR = sCTR;
-        this.CVR = CVR;
-        this.sCVR = sCVR;
-        this.CPA = CPA;
-        this.sCPA = sCPA;
-        this.ROAS = ROAS;
-        this.sROAS = sROAS;
-    }
-
-    public static PerformanceStatisticsDto of(Long creativeId, Long view, Long click, Long conversion, Long purchase, Long spend) {
-
-        String sSpend = formatToString(spend);
-        String sView = formatToString(view);
-        String sClick = formatToString(click);
-        String sConversion = formatToString(conversion);
-        String sPurchase = formatToString(purchase);
-        double CTR = calculateCTR(click, view);
-        String sCTR = String.format("%.2f", CTR * 100);
-        double CVR = calculateCVR(conversion, click);
-        String sCVR = String.format("%.2f", CVR * 100);
-        Long CPA = calculateCPA(spend, conversion);
-        String sCPA = formatToString(CPA);
-        double ROAS = calculateROAS(purchase, spend);
-        String sROAS = String.format("%.2f", ROAS * 100);
-
-        return new PerformanceStatisticsDto(creativeId, view, sView, click, sClick, conversion, sConversion, purchase, sPurchase, spend, sSpend, CTR, sCTR, CVR, sCVR, CPA, sCPA, ROAS, sROAS);
-    }
-
-    public static PerformanceStatisticsDto of(Long creativeId, Long view, String sView, Long click, String sClick, Long conversion, String sConversion, Long purchase, String sPurchase, Long spend, String sSpend, double CTR, String sCTR, double CVR, String sCVR, Long CPA, String sCPA, double ROAS, String sROAS) {
-
-        return new PerformanceStatisticsDto(creativeId, view, sView, click, sClick, conversion, sConversion, purchase, sPurchase, spend, sSpend, CTR, sCTR, CVR, sCVR, CPA, sCPA, ROAS, sROAS);
     }
 
     public void setCreativeIndicator(Long spend, Long view, Long click, Long conversion, Long purchase) {
@@ -110,10 +70,43 @@ public class PerformanceStatisticsDto {
         this.CPA = CPA;
         this.sCPA = sCPA;
         this.ROAS = ROAS;
-        this.sROAS =sROAS;
+        this.sROAS = sROAS;
     }
 
-    public void setCampaignTotalIndicator(Long spend, Long view, Long click, Long conversion, Long purchase) {
+    public void setCampaignIndicator(Long spend, Long view, Long click, Long conversion, Long purchase) {
+
+        String sBudget = formatToString(budget);
+        String sSpend = formatToString(spend);
+        String sView = formatToString(view);
+        String sClick = formatToString(click);
+        String sConversion = formatToString(conversion);
+        String sPurchase = formatToString(purchase);
+        double CTR = calculateCTR(click, view);
+        String sCTR = String.format("%.2f", CTR * 100);
+        double CVR = calculateCVR(conversion, click);
+        String sCVR = String.format("%.2f", CVR * 100);
+        Long CPA = calculateCPA(spend, conversion);
+        String sCPA = formatToString(CPA);
+        double ROAS = calculateROAS(purchase, spend);
+        String sROAS = String.format("%.2f", ROAS * 100);
+
+        this.sSpend = sSpend;
+        this.sBudget = sBudget;
+        this.sView = sView;
+        this.sClick = sClick;
+        this.sConversion = sConversion;
+        this.sPurchase = sPurchase;
+        this.CTR = CTR;
+        this.sCTR = sCTR;
+        this.CVR = CVR;
+        this.sCVR = sCVR;
+        this.CPA = CPA;
+        this.sCPA = sCPA;
+        this.ROAS = ROAS;
+        this.sROAS = sROAS;
+    }
+
+    public void setTotalIndicator(Long spend, Long view, Long click, Long conversion, Long purchase) {
 
         String sSpend = formatToString(spend);
         String sView = formatToString(view);
@@ -141,7 +134,7 @@ public class PerformanceStatisticsDto {
         this.CPA = CPA;
         this.sCPA = sCPA;
         this.ROAS = ROAS;
-        this.sROAS =sROAS;
+        this.sROAS = sROAS;
     }
 
     public static double calculateCTR(Long click, Long view) {

--- a/src/main/java/com/agencyplatformclonecoding/dto/response/PerformanceStatisticsResponse.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/response/PerformanceStatisticsResponse.java
@@ -7,8 +7,14 @@ import java.io.Serializable;
 import java.time.LocalDate;
 
 public record PerformanceStatisticsResponse(
+        String clientId,
+        Long campaignId,
         Long creativeId,
+        String username,
+        String name,
         String keyword,
+        Long budget,
+        String sBudget,
         Long bidingPrice,
         String sBidingPrice,
         Long view,
@@ -34,15 +40,21 @@ public record PerformanceStatisticsResponse(
 
 ) implements Serializable {
 
-    public static PerformanceStatisticsResponse of(Long creativeId, String keyword, Long bidingPrice, String sBidingPrice, Long view, String sView, Long click, String sClick, Long conversion, String sConversion, Long purchase, String sPurchase, Long spend, String sSpend, double CTR, String sCTR, double CVR, String sCVR, Long CPA, String sCPA, double ROAS, String sROAS, boolean activated, boolean deleted) {
-        return new PerformanceStatisticsResponse(creativeId, keyword, bidingPrice, sBidingPrice, view, sView, click, sClick, conversion, sConversion, purchase, sPurchase, spend, sSpend, CTR, sCTR, CVR, sCVR, CPA, sCPA, ROAS, sROAS, activated, deleted);
+    public static PerformanceStatisticsResponse of(String clientId, Long campaignId, Long creativeId, String username, String name, String keyword, Long budget, String sBudget, Long bidingPrice, String sBidingPrice, Long view, String sView, Long click, String sClick, Long conversion, String sConversion, Long purchase, String sPurchase, Long spend, String sSpend, double CTR, String sCTR, double CVR, String sCVR, Long CPA, String sCPA, double ROAS, String sROAS, boolean activated, boolean deleted) {
+        return new PerformanceStatisticsResponse(clientId, campaignId, creativeId, username, name, keyword, budget, sBudget, bidingPrice, sBidingPrice, view, sView, click, sClick, conversion, sConversion, purchase, sPurchase, spend, sSpend, CTR, sCTR, CVR, sCVR, CPA, sCPA, ROAS, sROAS, activated, deleted);
     }
 
     public static PerformanceStatisticsResponse from(PerformanceStatisticsDto dto) {
 
         return new PerformanceStatisticsResponse(
+                dto.getClientId(),
+                dto.getCampaignId(),
                 dto.getCreativeId(),
+                dto.getUsername(),
+                dto.getName(),
                 dto.getKeyword(),
+                dto.getBudget(),
+                dto.getSBudget(),
                 dto.getBidingPrice(),
                 dto.getSBidingPrice(),
                 dto.getView(),

--- a/src/main/java/com/agencyplatformclonecoding/service/PerformanceService.java
+++ b/src/main/java/com/agencyplatformclonecoding/service/PerformanceService.java
@@ -3,12 +3,8 @@ package com.agencyplatformclonecoding.service;
 import com.agencyplatformclonecoding.domain.Campaign;
 import com.agencyplatformclonecoding.domain.ClientUser;
 import com.agencyplatformclonecoding.domain.Creative;
-import com.agencyplatformclonecoding.domain.constrant.SearchType;
 import com.agencyplatformclonecoding.domain.constrant.StatisticsType;
-import com.agencyplatformclonecoding.dto.ClientUserDto;
-import com.agencyplatformclonecoding.dto.ClientUserWithCampaignsDto;
 import com.agencyplatformclonecoding.dto.PerformanceDto;
-import com.agencyplatformclonecoding.dto.PerformanceStatisticsDto;
 import com.agencyplatformclonecoding.exception.AdPlatformException;
 import com.agencyplatformclonecoding.exception.ErrorCode;
 import com.agencyplatformclonecoding.repository.*;
@@ -21,8 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
-import java.util.stream.Stream;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -34,7 +28,7 @@ public class PerformanceService {
     private final CreativeRepository creativeRepository;
     private final ClientUserRepository clientUserRepository;
     private final PerformanceRepository performanceRepository;
-    private final QueryRepository queryRepository;
+    private final StatisticsQueryRepository statisticsQueryRepository;
 
     @Transactional(readOnly = true)
     public PerformanceDto getPerformance(Long performanceId) {

--- a/src/main/java/com/agencyplatformclonecoding/service/StatisticsService.java
+++ b/src/main/java/com/agencyplatformclonecoding/service/StatisticsService.java
@@ -2,7 +2,7 @@ package com.agencyplatformclonecoding.service;
 
 import com.agencyplatformclonecoding.domain.constrant.StatisticsType;
 import com.agencyplatformclonecoding.dto.PerformanceStatisticsDto;
-import com.agencyplatformclonecoding.repository.QueryRepository;
+import com.agencyplatformclonecoding.repository.StatisticsQueryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -18,7 +18,7 @@ import java.util.List;
 @Service
 public class StatisticsService {
 
-    private final QueryRepository queryRepository;
+    private final StatisticsQueryRepository statisticsQueryRepository;
 
     // List 타입 반환
     @Transactional(readOnly = true)
@@ -30,12 +30,12 @@ public class StatisticsService {
         LocalDate startDateBeforeThirtyDays = lastDate.minusDays(30);
 
         if (statisticsType == null) {
-            return queryRepository.findByCreative_IdAndStatisticsDefault(creativeId, startDateBeforeThirtyDays, lastDate);
+            return statisticsQueryRepository.findByCreative_IdAndStatisticsDefault(creativeId, startDateBeforeThirtyDays, lastDate);
         }
 
         return switch (statisticsType) {
-            case BEFORE_WEEK -> queryRepository.findByCreative_IdAndStatisticsDefault(creativeId, startDateBeforeSevenDays, lastDate);
-            case BEFORE_MONTH -> queryRepository.findByCreative_IdAndStatisticsDefault(creativeId, startDateBeforeThirtyDays, lastDate);
+            case BEFORE_WEEK -> statisticsQueryRepository.findByCreative_IdAndStatisticsDefault(creativeId, startDateBeforeSevenDays, lastDate);
+            case BEFORE_MONTH -> statisticsQueryRepository.findByCreative_IdAndStatisticsDefault(creativeId, startDateBeforeThirtyDays, lastDate);
             case BEFORE_CUSTOM -> null;
         };
     }
@@ -50,12 +50,12 @@ public class StatisticsService {
         LocalDate startDateBeforeThirtyDays = lastDate.minusDays(30);
 
         if (statisticsType == null) {
-            return queryRepository.findByCampaign_IdAndStatisticsDefault(campaignId, startDateBeforeThirtyDays, lastDate);
+            return statisticsQueryRepository.findByCampaign_IdAndStatisticsDefault(campaignId, startDateBeforeThirtyDays, lastDate);
         }
 
         return switch (statisticsType) {
-            case BEFORE_WEEK -> queryRepository.findByCampaign_IdAndStatisticsDefault(campaignId, startDateBeforeSevenDays, lastDate);
-            case BEFORE_MONTH -> queryRepository.findByCampaign_IdAndStatisticsDefault(campaignId, startDateBeforeThirtyDays, lastDate);
+            case BEFORE_WEEK -> statisticsQueryRepository.findByCampaign_IdAndStatisticsDefault(campaignId, startDateBeforeSevenDays, lastDate);
+            case BEFORE_MONTH -> statisticsQueryRepository.findByCampaign_IdAndStatisticsDefault(campaignId, startDateBeforeThirtyDays, lastDate);
             case BEFORE_CUSTOM -> null;
         };
     }
@@ -69,12 +69,51 @@ public class StatisticsService {
         LocalDate startDateBeforeThirtyDays = lastDate.minusDays(30);
 
         if (statisticsType == null) {
-            return queryRepository.findByCampaign_IdAndTotalStatisticsDefault(campaignId, startDateBeforeThirtyDays, lastDate);
+            return statisticsQueryRepository.findByCampaign_IdAndTotalStatisticsDefault(campaignId, startDateBeforeThirtyDays, lastDate);
         }
 
         return switch (statisticsType) {
-            case BEFORE_WEEK -> queryRepository.findByCampaign_IdAndTotalStatisticsDefault(campaignId, startDateBeforeSevenDays, lastDate);
-            case BEFORE_MONTH -> queryRepository.findByCampaign_IdAndTotalStatisticsDefault(campaignId, startDateBeforeThirtyDays, lastDate);
+            case BEFORE_WEEK -> statisticsQueryRepository.findByCampaign_IdAndTotalStatisticsDefault(campaignId, startDateBeforeSevenDays, lastDate);
+            case BEFORE_MONTH -> statisticsQueryRepository.findByCampaign_IdAndTotalStatisticsDefault(campaignId, startDateBeforeThirtyDays, lastDate);
+            case BEFORE_CUSTOM -> null;
+        };
+    }
+
+    // List 타입 반환
+    @Transactional(readOnly = true)
+    public List<PerformanceStatisticsDto> clientWithCampaignsStatistics(StatisticsType statisticsType, String clientId) {
+
+        LocalDate lastDate = LocalDate.parse(LocalDate.now().minusDays(1)
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        LocalDate startDateBeforeSevenDays = lastDate.minusDays(6);
+        LocalDate startDateBeforeThirtyDays = lastDate.minusDays(30);
+
+        if (statisticsType == null) {
+            return statisticsQueryRepository.findByClientUser_IdAndStatisticsDefault(clientId, startDateBeforeThirtyDays, lastDate);
+        }
+
+        return switch (statisticsType) {
+            case BEFORE_WEEK -> statisticsQueryRepository.findByClientUser_IdAndStatisticsDefault(clientId, startDateBeforeSevenDays, lastDate);
+            case BEFORE_MONTH -> statisticsQueryRepository.findByClientUser_IdAndStatisticsDefault(clientId, startDateBeforeThirtyDays, lastDate);
+            case BEFORE_CUSTOM -> null;
+        };
+    }
+
+    @Transactional(readOnly = true)
+    public List<PerformanceStatisticsDto> totalCampaignsPerformanceStatistics(StatisticsType statisticsType, String clientId) {
+
+        LocalDate lastDate = LocalDate.parse(LocalDate.now().minusDays(1)
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        LocalDate startDateBeforeSevenDays = lastDate.minusDays(6);
+        LocalDate startDateBeforeThirtyDays = lastDate.minusDays(30);
+
+        if (statisticsType == null) {
+            return statisticsQueryRepository.findByClientUser_IdAndTotalStatisticsDefault(clientId, startDateBeforeThirtyDays, lastDate);
+        }
+
+        return switch (statisticsType) {
+            case BEFORE_WEEK -> statisticsQueryRepository.findByClientUser_IdAndTotalStatisticsDefault(clientId, startDateBeforeSevenDays, lastDate);
+            case BEFORE_MONTH -> statisticsQueryRepository.findByClientUser_IdAndTotalStatisticsDefault(clientId, startDateBeforeThirtyDays, lastDate);
             case BEFORE_CUSTOM -> null;
         };
     }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -112,12 +112,12 @@ insert into client_user (client_id, created_at, created_by, modified_at, modifie
 
 -- 캠페인 관련 (45개)
 insert into campaign (client_id, created_at, created_by, modified_at, modified_by, budget, name, activated, deleted) values
-('c01', '2022-08-14 13:18:02', 'Yasmin', '2022-04-25 08:47:01', 'Yasmin', 8090, '2022-08-14 13:18:02, 8090', true, false),
-('c01', '2022-03-23 14:56:28', 'Salome', '2021-10-01 16:25:54', 'Salome', 14122, '2022-03-23 14:56:28, 14122', false, false),
-('c01', '2021-09-17 12:33:34', 'Borden', '2022-07-01 01:14:40', 'Borden', 13438, '2021-09-17 12:33:34, 13438', false, false),
-('c01', '2022-06-30 15:35:08', 'Kassi', '2021-10-22 14:57:57', 'Kassi', 18263, '2022-06-30 15:35:08, 18263', false, false),
-('c01', '2021-10-12 13:26:42', 'Alethea', '2021-09-24 01:08:37', 'Alethea', 6243, '2021-10-12 13:26:42, 6243', false, false),
-('c01', '2021-09-09 01:36:42', 'Indira', '2021-09-05 01:23:52', 'Indira', 11358, '2021-09-09 01:36:42, 11358', false, false),
+('c01', '2022-08-14 13:18:02', 'Yasmin', '2022-04-25 08:47:01', 'Yasmin', 8090, '서울지역캠페인', true, false),
+('c01', '2022-03-23 14:56:28', 'Salome', '2021-10-01 16:25:54', 'Salome', 14122, '아이폰추천매장', true, false),
+('c01', '2021-09-17 12:33:34', 'Borden', '2022-07-01 01:14:40', 'Borden', 13438, '미사용캠페인1', false, false),
+('c01', '2022-06-30 15:35:08', 'Kassi', '2021-10-22 14:57:57', 'Kassi', 18263, '미사용캠페인2', false, false),
+('c01', '2021-10-12 13:26:42', 'Alethea', '2021-09-24 01:08:37', 'Alethea', 6243, '미사용캠페인3', false, false),
+('c01', '2021-09-09 01:36:42', 'Indira', '2021-09-05 01:23:52', 'Indira', 11358, '미사용캠페인4', false, false),
 ('c02', '2022-05-22 21:20:16', 'Axel', '2022-06-22 00:44:12', 'Axel', 4327, '2022-05-22 21:20:16, 4327', false, false),
 ('c03', '2021-10-30 09:15:58', 'Deane', '2022-05-15 22:06:54', 'Deane', 19384, '2021-10-30 09:15:58, 19384', false, false),
 ('c04', '2022-04-06 19:53:11', 'Theresina', '2022-07-11 10:56:48', 'Theresina', 15381, '2022-04-06 19:53:11, 15381', false, false),
@@ -158,7 +158,7 @@ insert into campaign (client_id, created_at, created_by, modified_at, modified_b
 ('c39', '2022-01-16 10:54:00', 'Bendicty', '2022-06-01 00:37:26', 'Bendicty', 19564, '2022-01-16 10:54:00, 19564', false, false),
 ('c40', '2021-09-28 20:24:46', 'Griff', '2022-02-01 14:01:53', 'Griff', 17917, '2021-09-28 20:24:46, 17917', false, false);
 
--- 소재 관련 (5개)
+-- 소재 관련 (14개)
 insert into creative (campaign_id, created_at, created_by, modified_at, modified_by, biding_price, keyword, activated, deleted) values
 (1, '2022-07-13 01:32:28', 'Karoline', '2021-10-26 02:46:03', 'Karoline', 7224, '강남핸드폰매장', true, false),
 (1, '2022-07-10 04:40:02', 'Ashien', '2022-07-08 09:18:39', 'Ashien', 4503, '서울핸드폰매장', true, false),
@@ -170,7 +170,10 @@ insert into creative (campaign_id, created_at, created_by, modified_at, modified
 (1, '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', 5423, '핸드폰견적', false, false),
 (1, '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', 5423, '강남핸드폰견적', false, false),
 (1, '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', 5423, '서울핸드폰견적', false, false),
-(1, '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', 5423, '저가형핸드폰', false, false);
+(1, '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', 5423, '저가형핸드폰', false, false),
+(2, '2022-07-13 01:32:28', 'Karoline', '2021-10-26 02:46:03', 'Karoline', 7224, '아이폰자급제', true, false),
+(2, '2022-07-10 04:40:02', 'Ashien', '2022-07-08 09:18:39', 'Ashien', 4503, '아이폰약정', true, false),
+(2, '2021-11-26 01:47:21', 'Flossie', '2022-01-29 02:01:15', 'Flossie', 5463, '아이폰색상추천', false, false);
 
 -- 소재 실적 관련 (1개 소재, 31일치)
 insert into performance (creative_id, created_at, view, click, conversion, purchase, spend) values
@@ -235,4 +238,31 @@ insert into performance (creative_id, created_at, view, click, conversion, purch
 (2, DATE_SUB(now(), INTERVAL 4 DAY), 12, 23, 14, 7563000, 293534),
 (2, DATE_SUB(now(), INTERVAL 3 DAY), 64, 41, 16, 8534000, 483424),
 (2, DATE_SUB(now(), INTERVAL 2 DAY), 45, 54, 8, 945000, 465632),
-(2, DATE_SUB(now(), INTERVAL 1 DAY), 55, 55, 34, 5653000, 634428);
+(2, DATE_SUB(now(), INTERVAL 1 DAY), 55, 55, 34, 5653000, 634428),
+(12, DATE_SUB(now(), INTERVAL 13 DAY), 54, 22, 5, 6772000, 445466),
+(12, DATE_SUB(now(), INTERVAL 12 DAY), 23, 11, 6, 4734000, 435234),
+(12, DATE_SUB(now(), INTERVAL 11 DAY), 41, 36, 14, 6452000, 392348),
+(12, DATE_SUB(now(), INTERVAL 10 DAY), 44, 35, 14, 4143000, 254530),
+(12, DATE_SUB(now(), INTERVAL 9 DAY), 72, 34, 12, 1645000, 165346),
+(12, DATE_SUB(now(), INTERVAL 8 DAY), 81, 36, 10, 663000, 292434),
+(12, DATE_SUB(now(), INTERVAL 7 DAY), 42, 25, 6, 225000, 95342),
+(12, DATE_SUB(now(), INTERVAL 6 DAY), 49, 24, 8, 4104000, 232340),
+(12, DATE_SUB(now(), INTERVAL 5 DAY), 37, 26, 12, 3235000, 395346),
+(12, DATE_SUB(now(), INTERVAL 4 DAY), 25, 15, 8, 6563000, 193534),
+(12, DATE_SUB(now(), INTERVAL 3 DAY), 54, 31, 12, 3534000, 283424),
+(12, DATE_SUB(now(), INTERVAL 2 DAY), 35, 24, 8, 745000, 165632),
+(12, DATE_SUB(now(), INTERVAL 1 DAY), 45, 25, 12, 3653000, 334428),
+(13, DATE_SUB(now(), INTERVAL 14 DAY), 799, 65, 12, 1750000, 241800),
+(13, DATE_SUB(now(), INTERVAL 13 DAY), 594, 64, 29, 2209000, 379056),
+(13, DATE_SUB(now(), INTERVAL 12 DAY), 234, 41, 2, 6854000, 285144),
+(13, DATE_SUB(now(), INTERVAL 11 DAY), 418, 67, 7, 5596000, 528488),
+(13, DATE_SUB(now(), INTERVAL 10 DAY), 404, 35, 1, 4278000, 341800),
+(13, DATE_SUB(now(), INTERVAL 9 DAY), 712, 44, 3, 1859000, 262336),
+(13, DATE_SUB(now(), INTERVAL 8 DAY), 491, 36, 3, 1713000, 321264),
+(13, DATE_SUB(now(), INTERVAL 7 DAY), 452, 53, 21, 446000, 55112),
+(13, DATE_SUB(now(), INTERVAL 6 DAY), 859, 25, 12, 1260000, 197320),
+(13, DATE_SUB(now(), INTERVAL 5 DAY), 647, 49, 25, 2307000, 470696),
+(13, DATE_SUB(now(), INTERVAL 4 DAY), 142, 31, 26, 5790000, 268424),
+(13, DATE_SUB(now(), INTERVAL 3 DAY), 504, 21, 16, 5620000, 112904),
+(13, DATE_SUB(now(), INTERVAL 2 DAY), 350, 43, 8, 249000, 27352),
+(13, DATE_SUB(now(), INTERVAL 1 DAY), 435, 67, 34, 4844000, 200728);

--- a/src/main/resources/static/css/layout.css
+++ b/src/main/resources/static/css/layout.css
@@ -8,12 +8,12 @@ main {
     height: 100%;
 }
 
-h1{
+h1 {
     font-size: 40px;
 }
 
 .justify-content-md-between {
-    justify-content: space-between!important;
+    justify-content: space-between !important;
 }
 
 .container {
@@ -69,7 +69,7 @@ main {
 }
 
 .create-btn {
-    display: flex!important;
+    display: flex !important;
     flex-direction: row-reverse;
 }
 
@@ -84,4 +84,9 @@ th, td {
 
 .row.right {
     flex-direction: row-reverse;
+}
+
+div {
+    overflow: hidden;
+    height: auto;
 }

--- a/src/main/resources/templates/manage/campaign.html
+++ b/src/main/resources/templates/manage/campaign.html
@@ -78,6 +78,8 @@
 
     <div class="row right">
       <div class="create-btn d-grid gap-2 justify-content-md">
+        <a class="stats-btn btn btn-primary" role="button" id="statistics_type_week">최근 7일간 통계</a>
+        <a class="stats-btn btn btn-primary" role="button" id="statistics_type_month">최근 30일간 통계</a>
         <a class="btn btn-primary me-md-2" role="button" id="create-campaign">캠페인 생성</a>
       </div>
     </div>
@@ -96,6 +98,82 @@
           <td class="user-id"><a>client1</a></td>
           <td class="nickname">코코볼자동차</td>
           <td class="category">자동차</td>
+        </tr>
+        </tbody>
+      </table>
+      <table class="table" id="client-statistics-info">
+        <thead>
+        <tr>
+          <th class="view" style="width: 75px;"><a>총 노출수</a></th>
+          <th class="click" style="width: 75px;"><a>총 클릭수</a></th>
+          <th class="conversion" style="width: 75px;"><a>총 전환수</a></th>
+          <th class="purchase" style="width: 150px;"><a>총 구매액</a></th>
+          <th class="spend" style="width: 125px;"><a>총 소진액</a></th>
+          <th class="CTR" style="width: 75px;"><a>클릭률</a></th>
+          <th class="CVR" style="width: 75px;"><a>전환률</a></th>
+          <th class="CPA" style="width: 100px;"><a>CPA</a></th>
+          <th class="ROAS" style="width: 100px;"><a>ROAS</a></th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <td class="view"><a>1000</a></td>
+          <td class="click"><a>100</a></td>
+          <td class="conversion"><a>10</a></td>
+          <td class="purchase"><a>100000</a></td>
+          <td class="spend"><a>20000</a></td>
+          <td class="CTR"><a>0.1</a></td>
+          <td class="CVR"><a>0.1</a></td>
+          <td class="CPA"><a>2000</a></td>
+          <td class="ROAS"><a>500</a></td>
+        </tr>
+        </tbody>
+      </table>
+      <table class="table" id="statistics-table">
+        <thead>
+        <tr>
+          <th class="id"><a>ID</a></th>
+          <th class="name" style="width: 150px;"><a>캠페인명</a></th>
+          <th class="budget" style="width: 100px;"><a>예산</a></th>
+          <th class="view" style="width: 75px;"><a>노출수</a></th>
+          <th class="click" style="width: 75px;"><a>클릭수</a></th>
+          <th class="conversion" style="width: 75px;"><a>전환수</a></th>
+          <th class="purchase" style="width: 150px;"><a>구매액</a></th>
+          <th class="spend" style="width: 125px;"><a>소진액</a></th>
+          <th class="CTR" style="width: 75px;"><a>클릭률</a></th>
+          <th class="CVR" style="width: 75px;"><a>전환률</a></th>
+          <th class="CPA" style="width: 100px;"><a>CPA</a></th>
+          <th class="ROAS" style="width: 100px;"><a>ROAS</a></th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <td class="id">144</td>
+          <td class="name">코코볼추천</td>
+          <td class="budget">10000</td>
+          <td class="view"><a>1000</a></td>
+          <td class="click"><a>100</a></td>
+          <td class="conversion"><a>10</a></td>
+          <td class="purchase"><a>100000</a></td>
+          <td class="spend"><a>20000</a></td>
+          <td class="CTR"><a>0.1</a></td>
+          <td class="CVR"><a>0.1</a></td>
+          <td class="CPA"><a>2000</a></td>
+          <td class="ROAS"><a>500</a></td>
+        </tr>
+        <tr>
+          <td class="date">2022-08-02</td>
+          <td class="view"><a>1000</a></td>
+          <td class="click"><a>100</a></td>
+          <td class="conversion"><a>10</a></td>
+          <td class="purchase"><a>100000</a></td>
+        </tr>
+        <tr>
+          <td class="date">2022-08-01</td>
+          <td class="view"><a>1000</a></td>
+          <td class="click"><a>100</a></td>
+          <td class="conversion"><a>10</a></td>
+          <td class="purchase"><a>100000</a></td>
         </tr>
         </tbody>
       </table>

--- a/src/main/resources/templates/manage/campaign.th.xml
+++ b/src/main/resources/templates/manage/campaign.th.xml
@@ -8,6 +8,9 @@
 
     <attr sel="#create-campaign" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/form'}"/>
 
+    <attr sel="#statistics_type_week" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(statisticsType=BEFORE_WEEK)}" th:method="get" />
+    <attr sel="#statistics_type_month" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(statisticsType=BEFORE_MONTH)}" th:method="get" />
+
     <attr sel="#client-info">
       <attr sel="tbody" th:remove="all-but-first">
         <attr sel="td.user-id" th:text="${clientUser.userId}" />
@@ -16,15 +19,52 @@
       </attr>
     </attr>
 
+    <attr sel="#client-statistics-info">
+        <attr sel="tbody" th:remove="all-but-first">
+          <attr sel="tr[0]" th:each="totalCampaignStatistic : ${totalCampaignStatistics}">
+            <attr sel="td.view" th:text="${totalCampaignStatistic.sView}" />
+            <attr sel="td.click" th:text="${totalCampaignStatistic.sClick}" />
+            <attr sel="td.conversion" th:text="${totalCampaignStatistic.sConversion}" />
+            <attr sel="td.purchase" th:text="${totalCampaignStatistic.sPurchase} + '원'"/>
+            <attr sel="td.spend" th:text="${totalCampaignStatistic.sSpend} + '원'" />
+            <attr sel="td.CTR" th:text="${totalCampaignStatistic.sCTR} + '%'" />
+            <attr sel="td.CVR" th:text="${totalCampaignStatistic.sCVR} + '%'"/>
+            <attr sel="td.CPA" th:text="${totalCampaignStatistic.sCPA} + '원'" />
+            <attr sel="td.ROAS" th:text="${totalCampaignStatistic.sROAS} + '%'" />
+          </attr>
+        </attr>
+      </attr>
+
+    <attr sel="#statistics-table">
+        <attr sel="tbody" th:remove="all-but-first">
+          <attr sel="tr[0]" th:each="campaignStatistic : ${campaignStatistics}">
+            <attr sel="td.id" th:text="${campaignStatistic.campaignId}" />
+            <attr sel="td.name" th:text="${campaignStatistic.name}" />
+            <attr sel="td.budget" th:text="${campaignStatistic.sBudget} + '원'"/>
+            <attr sel="td.view" th:text="${campaignStatistic.sView}" />
+            <attr sel="td.click" th:text="${campaignStatistic.sClick}" />
+            <attr sel="td.conversion" th:text="${campaignStatistic.sConversion}" />
+            <attr sel="td.purchase" th:text="${campaignStatistic.sPurchase} + '원'"/>
+            <attr sel="td.spend" th:text="${campaignStatistic.sSpend} + '원'" />
+            <attr sel="td.CTR" th:text="${campaignStatistic.sCTR} + '%'" />
+            <attr sel="td.CVR" th:text="${campaignStatistic.sCVR} + '%'"/>
+            <attr sel="td.CPA" th:text="${campaignStatistic.sCPA} + '원'" />
+            <attr sel="td.ROAS" th:text="${campaignStatistic.sROAS} + '%'" />
+          </attr>
+        </attr>
+      </attr>
+
     <attr sel="#campaign-table">
       <attr sel="thead/tr">
         <attr sel="th.activate-status/a" th:text="'상태'" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(
       page=${campaigns.number},
-      sort='activated' + (*{sort.getOrderFor('activated')} != null ? (*{sort.getOrderFor('activated').direction.name} != 'DESC' ? ',desc' : '') : '')
+      sort='activated' + (*{sort.getOrderFor('activated')} != null ? (*{sort.getOrderFor('activated').direction.name} != 'DESC' ? ',desc' : '') : ''),
+      statisticsType=${param.statisticsType}
   )}"/>
         <attr sel="th.budget/a" th:text="'예산'" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(
       page=${campaigns.number},
-      sort='budget' + (*{sort.getOrderFor('budget')} != null ? (*{sort.getOrderFor('budget').direction.name} != 'DESC' ? ',desc' : '') : '')
+      sort='budget' + (*{sort.getOrderFor('budget')} != null ? (*{sort.getOrderFor('budget').direction.name} != 'DESC' ? ',desc' : '') : ''),
+      statisticsType=${param.statisticsType}
   )}"/>
       </attr>
 
@@ -46,19 +86,19 @@
     <attr sel="#pagination">
       <attr sel="li[0]/a"
             th:text="'previous'"
-            th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(page=${campaigns.number - 1})}"
+            th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(page=${campaigns.number - 1}, statisticsType=${param.statisticsType})}"
             th:class="'page-link' + (${campaigns.number} <= 0 ? ' disabled' : '')"
       />
       <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
         <attr sel="a"
               th:text="${pageNumber + 1}"
-              th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(page=${pageNumber})}"
+              th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(page=${pageNumber}, statisticsType=${param.statisticsType})}"
               th:class="'page-link' + (${pageNumber} == ${campaigns.number} ? ' disabled' : '')"
         />
       </attr>
       <attr sel="li[2]/a"
             th:text="'next'"
-            th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(page=${campaigns.number + 1})}"
+            th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(page=${campaigns.number + 1}, statisticsType=${param.statisticsType})}"
             th:class="'page-link' + (${campaigns.number} >= ${campaigns.totalPages - 1} ? ' disabled' : '')"
       />
     </attr>

--- a/src/main/resources/templates/manage/creative.th.xml
+++ b/src/main/resources/templates/manage/creative.th.xml
@@ -35,11 +35,13 @@
       <attr sel="thead/tr">
         <attr sel="th.activate-status/a" th:text="'상태'" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(
       page=${creatives.number},
-      sort='activated' + (*{sort.getOrderFor('activated')} != null ? (*{sort.getOrderFor('activated').direction.name} != 'DESC' ? ',desc' : '') : '')
+      sort='activated' + (*{sort.getOrderFor('activated')} != null ? (*{sort.getOrderFor('activated').direction.name} != 'DESC' ? ',desc' : '') : ''),
+      statisticsType=${param.statisticsType}
   )}"/>
         <attr sel="th.biding-price/a" th:text="'입찰가'" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(
       page=${creatives.number},
-      sort='bidingPrice' + (*{sort.getOrderFor('bidingPrice')} != null ? (*{sort.getOrderFor('bidingPrice').direction.name} != 'DESC' ? ',desc' : '') : '')
+      sort='bidingPrice' + (*{sort.getOrderFor('bidingPrice')} != null ? (*{sort.getOrderFor('bidingPrice').direction.name} != 'DESC' ? ',desc' : '') : ''),
+      statisticsType=${param.statisticsType}
   )}"/>
       </attr>
 
@@ -80,19 +82,19 @@
     <attr sel="#pagination">
       <attr sel="li[0]/a"
             th:text="'previous'"
-            th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(page=${creatives.number - 1})}"
+            th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(page=${creatives.number - 1}, statisticsType=${param.statisticsType})}"
             th:class="'page-link' + (${creatives.number} <= 0 ? ' disabled' : '')"
       />
       <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
         <attr sel="a"
               th:text="${pageNumber + 1}"
-              th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(page=${pageNumber})}"
+              th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(page=${pageNumber}, statisticsType=${param.statisticsType})}"
               th:class="'page-link' + (${pageNumber} == ${creatives.number} ? ' disabled' : '')"
         />
       </attr>
       <attr sel="li[2]/a"
             th:text="'next'"
-            th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(page=${creatives.number + 1})}"
+            th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(page=${creatives.number + 1}, statisticsType=${param.statisticsType})}"
             th:class="'page-link' + (${creatives.number} >= ${creatives.totalPages - 1} ? ' disabled' : '')"
       />
     </attr>


### PR DESCRIPTION
소재와 연결된 실적들에 대해 통계 기능이 구현되었으므로,
광고주 페이지 (캠패인 리스트 및 관리 페이지)에서 소재를 모아놓은 캠페인에 대한 통계 기능을 제공할 수 있도록 수정한다.

* [x] 통계 쿼리 작성 및 테스트 -> QueryDSL로 변환
* [x] 일일 통계 기능 구현
* [x] 최근 1주일 간의 통계 보기 기능 구현
* [x] 최근 30일 간의 통계 보기 기능 구현

This closes #110 