### PR TITLE
광고 관리 페이지 (광고주 리스트) 수정 및 통계 기능 구현

### DIFF
--- a/src/main/java/com/agencyplatformclonecoding/controller/ManageController.java
+++ b/src/main/java/com/agencyplatformclonecoding/controller/ManageController.java
@@ -6,6 +6,7 @@ import com.agencyplatformclonecoding.dto.response.CampaignResponse;
 import com.agencyplatformclonecoding.dto.response.ClientUserResponse;
 import com.agencyplatformclonecoding.dto.response.ClientUserWithCampaignsResponse;
 import com.agencyplatformclonecoding.dto.response.PerformanceStatisticsResponse;
+import com.agencyplatformclonecoding.repository.StatisticsQueryRepository;
 import com.agencyplatformclonecoding.service.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -31,7 +32,6 @@ public class ManageController {
 
     private final ManageService manageService;
     private final CampaignService campaignService;
-    private final CreativeService creativeService;
     private final PaginationService paginationService;
     private final StatisticsService statisticsService;
 
@@ -39,14 +39,19 @@ public class ManageController {
     public String manage(
             @RequestParam(required = false) SearchType searchType,
             @RequestParam(required = false) String searchValue,
+            @RequestParam(required = false) StatisticsType statisticsType,
             @PageableDefault(size = 10, sort = "userId", direction = Sort.Direction.ASC) Pageable pageable,
             ModelMap map
     ) {
         Page<ClientUserResponse> clientUsers = manageService.searchClientUsers(searchType, searchValue, pageable)
                 .map(ClientUserResponse::from);
+        Set<PerformanceStatisticsResponse> totalClientSpendStatistics = statisticsService.totalSpendStatistics(statisticsType)
+                .stream().map(PerformanceStatisticsResponse::from).collect(Collectors.toCollection(LinkedHashSet::new));
         List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), clientUsers.getTotalPages());
+
         map.addAttribute("clientUsers", clientUsers);
         map.addAttribute("paginationBarNumbers", barNumbers);
+        map.addAttribute("totalClientSpendStatistics", totalClientSpendStatistics);
         map.addAttribute("searchTypes", SearchType.values());
 
         return "manage/index";

--- a/src/main/java/com/agencyplatformclonecoding/dto/PerformanceStatisticsDto.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/PerformanceStatisticsDto.java
@@ -3,6 +3,7 @@ package com.agencyplatformclonecoding.dto;
 import lombok.Getter;
 
 import java.text.DecimalFormat;
+import java.time.LocalDate;
 
 @Getter
 public class PerformanceStatisticsDto {
@@ -36,6 +37,8 @@ public class PerformanceStatisticsDto {
     String sROAS;
     boolean activated;
     boolean deleted;
+    LocalDate startDate;
+    LocalDate lastDate;
 
     public PerformanceStatisticsDto() {
     }
@@ -135,6 +138,19 @@ public class PerformanceStatisticsDto {
         this.sCPA = sCPA;
         this.ROAS = ROAS;
         this.sROAS = sROAS;
+    }
+
+    public void setSpendIndicator(Long spend) {
+
+        String sSpend = formatToString(spend);
+
+        this.sSpend = sSpend;
+    }
+
+    public void setStartDateAndLastDate(LocalDate startDate, LocalDate lastDate) {
+
+        this.startDate = startDate;
+        this.lastDate = lastDate;
     }
 
     public static double calculateCTR(Long click, Long view) {

--- a/src/main/java/com/agencyplatformclonecoding/dto/response/PerformanceStatisticsResponse.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/response/PerformanceStatisticsResponse.java
@@ -36,12 +36,14 @@ public record PerformanceStatisticsResponse(
         double ROAS,
         String sROAS,
         boolean activated,
-        boolean deleted
+        boolean deleted,
+        LocalDate startDate,
+        LocalDate lastDate
 
 ) implements Serializable {
 
-    public static PerformanceStatisticsResponse of(String clientId, Long campaignId, Long creativeId, String username, String name, String keyword, Long budget, String sBudget, Long bidingPrice, String sBidingPrice, Long view, String sView, Long click, String sClick, Long conversion, String sConversion, Long purchase, String sPurchase, Long spend, String sSpend, double CTR, String sCTR, double CVR, String sCVR, Long CPA, String sCPA, double ROAS, String sROAS, boolean activated, boolean deleted) {
-        return new PerformanceStatisticsResponse(clientId, campaignId, creativeId, username, name, keyword, budget, sBudget, bidingPrice, sBidingPrice, view, sView, click, sClick, conversion, sConversion, purchase, sPurchase, spend, sSpend, CTR, sCTR, CVR, sCVR, CPA, sCPA, ROAS, sROAS, activated, deleted);
+    public static PerformanceStatisticsResponse of(String clientId, Long campaignId, Long creativeId, String username, String name, String keyword, Long budget, String sBudget, Long bidingPrice, String sBidingPrice, Long view, String sView, Long click, String sClick, Long conversion, String sConversion, Long purchase, String sPurchase, Long spend, String sSpend, double CTR, String sCTR, double CVR, String sCVR, Long CPA, String sCPA, double ROAS, String sROAS, boolean activated, boolean deleted, LocalDate startDate, LocalDate lastDate) {
+        return new PerformanceStatisticsResponse(clientId, campaignId, creativeId, username, name, keyword, budget, sBudget, bidingPrice, sBidingPrice, view, sView, click, sClick, conversion, sConversion, purchase, sPurchase, spend, sSpend, CTR, sCTR, CVR, sCVR, CPA, sCPA, ROAS, sROAS, activated, deleted, startDate, lastDate);
     }
 
     public static PerformanceStatisticsResponse from(PerformanceStatisticsDto dto) {
@@ -76,7 +78,9 @@ public record PerformanceStatisticsResponse(
                 dto.getROAS(),
                 dto.getSROAS(),
                 dto.isActivated(),
-                dto.isDeleted()
+                dto.isDeleted(),
+                dto.getStartDate(),
+                dto.getLastDate()
         );
     }
 }

--- a/src/main/java/com/agencyplatformclonecoding/repository/StatisticsQueryRepository.java
+++ b/src/main/java/com/agencyplatformclonecoding/repository/StatisticsQueryRepository.java
@@ -216,6 +216,31 @@ public class StatisticsQueryRepository {
         return results;
     }
 
+    public List<PerformanceStatisticsDto> findClientUserSpendTotalStatisticsDefault(@Param("startDate") LocalDate startDate,
+                                                                                    @Param("lastDate") LocalDate lastDate
+    ) {
+        List<PerformanceStatisticsDto> results = jpaQueryFactory
+                .select(Projections.fields(PerformanceStatisticsDto.class,
+                        performance.spend.sum().as("spend")
+                ))
+                .from(performance)
+                .leftJoin(performance.creative, creative)
+                .where(
+                        performance.createdAt.between(startDate, lastDate),
+                        creative.deleted.eq(false)
+                )
+                .fetch();
+
+        for (PerformanceStatisticsDto result : results) {
+            Long spend = result.getSpend();
+
+            result.setSpendIndicator(spend); // spend 세팅용 메소드
+            result.setStartDateAndLastDate(startDate, lastDate);
+        }
+
+        return results;
+    }
+
     private StringTemplate localDateTimeFormat() {
         return Expressions
                 .stringTemplate("DATE_FORMAT({0}, {1})", performance.createdAt, ConstantImpl.create("%Y-%m-%d"));

--- a/src/main/java/com/agencyplatformclonecoding/service/StatisticsService.java
+++ b/src/main/java/com/agencyplatformclonecoding/service/StatisticsService.java
@@ -20,7 +20,6 @@ public class StatisticsService {
 
     private final StatisticsQueryRepository statisticsQueryRepository;
 
-    // List 타입 반환
     @Transactional(readOnly = true)
     public List<PerformanceStatisticsDto> totalPerformanceStatistics(StatisticsType statisticsType, Long creativeId) {
 
@@ -40,7 +39,6 @@ public class StatisticsService {
         };
     }
 
-    // List 타입 반환
     @Transactional(readOnly = true)
     public List<PerformanceStatisticsDto> creativesWithPerformanceStatistics(StatisticsType statisticsType, Long campaignId) {
 
@@ -79,7 +77,6 @@ public class StatisticsService {
         };
     }
 
-    // List 타입 반환
     @Transactional(readOnly = true)
     public List<PerformanceStatisticsDto> clientWithCampaignsStatistics(StatisticsType statisticsType, String clientId) {
 
@@ -114,6 +111,25 @@ public class StatisticsService {
         return switch (statisticsType) {
             case BEFORE_WEEK -> statisticsQueryRepository.findByClientUser_IdAndTotalStatisticsDefault(clientId, startDateBeforeSevenDays, lastDate);
             case BEFORE_MONTH -> statisticsQueryRepository.findByClientUser_IdAndTotalStatisticsDefault(clientId, startDateBeforeThirtyDays, lastDate);
+            case BEFORE_CUSTOM -> null;
+        };
+    }
+
+    @Transactional(readOnly = true)
+    public List<PerformanceStatisticsDto> totalSpendStatistics(StatisticsType statisticsType) {
+
+        LocalDate lastDate = LocalDate.parse(LocalDate.now().minusDays(1)
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        LocalDate startDateBeforeSevenDays = lastDate.minusDays(6);
+        LocalDate startDateBeforeThirtyDays = lastDate.minusDays(30);
+
+        if (statisticsType == null) {
+            return statisticsQueryRepository.findClientUserSpendTotalStatisticsDefault(startDateBeforeThirtyDays, lastDate);
+        }
+
+        return switch (statisticsType) {
+            case BEFORE_WEEK -> statisticsQueryRepository.findClientUserSpendTotalStatisticsDefault(startDateBeforeSevenDays, lastDate);
+            case BEFORE_MONTH -> statisticsQueryRepository.findClientUserSpendTotalStatisticsDefault(startDateBeforeThirtyDays, lastDate);
             case BEFORE_CUSTOM -> null;
         };
     }

--- a/src/main/resources/static/css/layout.css
+++ b/src/main/resources/static/css/layout.css
@@ -1,13 +1,5 @@
 @charset "utf-8";
 
-html, body {
-    height: 100%;
-}
-
-main {
-    height: 100%;
-}
-
 h1 {
     font-size: 40px;
 }

--- a/src/main/resources/templates/manage/index.html
+++ b/src/main/resources/templates/manage/index.html
@@ -106,7 +106,26 @@
       </div>
     </div>
 
+    <div class="row right">
+        <a class="stats-btn btn btn-primary" role="button" id="statistics_type_week">최근 7일간 통계</a>
+        <a class="stats-btn btn btn-primary" role="button" id="statistics_type_month">최근 30일간 통계</a>
+    </div>
+
     <div class="row">
+      <table class="table" id="client-spend-statistics-info">
+        <thead>
+        <tr>
+          <th class="date" style="width: 125px;"><a>조회 기간</a></th>
+          <th class="spend" style="width: 125px;"><a>총 소진액</a></th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <td class="date"><a>2022-09-24 ~ 2022-10-24</a></td>
+          <td class="spend"><a>20000</a></td>
+        </tr>
+        </tbody>
+      </table>
       <table class="table" id="client-table">
         <thead>
         <tr>
@@ -125,65 +144,7 @@
           <td class="agent-name">김코코볼</td>
           <td class="button"><a class="btn btn-primary" role="button" id="client-manage">광고 관리</a></td>
         </tr>
-        <tr>
-          <td class="user-id"><a>client2</a></td>
-          <td class="nickname">코코볼전자</td>
-          <td class="agent-name">김코코볼</td>
-          <td class="button"><a class="btn btn-primary" role="button" id="client-manage">광고 관리</a></td>
-        </tr>
-        <tr>
-          <td class="user-id"><a>client3</a></td>
-          <td class="nickname">코코볼물산</td>
-          <td class="agent-name">김지오</td>
-          <td class="button"><a class="btn btn-primary" role="button" id="client-manage">광고 관리</a></td>
-        </tr>
-        <tr>
-          <td class="user-id"><a>client4</a></td>
-          <td class="nickname">코코볼식품</td>
-          <td class="agent-name">김지오</td>
-          <td class="button"><a class="btn btn-primary" role="button" id="client-manage">광고 관리</a></td>
-        </tr>
-        <tr>
-          <td class="user-id"><a>client5</a></td>
-          <td class="nickname">코코볼생명보험</td>
-          <td class="agent-name">김지오</td>
-          <td class="button"><a class="btn btn-primary" role="button" id="client-manage">광고 관리</a></td>
-        </tr>
-        <tr>
-          <td class="user-id"><a>client6</a></td>
-          <td class="nickname">코코볼뱅크</td>
-          <td class="agent-name">김호빵</td>
-          <td class="button"><a class="btn btn-primary" role="button" id="client-manage">광고 관리</a></td>
-        </tr>
-        <tr>
-          <td class="user-id"><a>client7</a></td>
-          <td class="nickname">코코볼의집</td>
-          <td class="agent-name">김호빵</td>
-          <td class="button"><a class="btn btn-primary" role="button" id="client-manage">광고 관리</a></td>
-        </tr>
-        <tr>
-          <td class="user-id"><a>client8</a></td>
-          <td class="nickname">코코볼리</td>
-          <td class="agent-name">김호떡</td>
-          <td class="button"><a class="btn btn-primary" role="button" id="client-manage">광고 관리</a></td>
-        </tr>
-        <tr>
-          <td class="user-id"><a>client9</a></td>
-          <td class="nickname">코코볼마켓</td>
-          <td class="agent-name">김호떡</td>
-          <td class="button"><a class="btn btn-primary" role="button" id="client-manage">광고 관리</a></td>
-        </tr>
-        <tr>
-          <td class="user-id"><a>client10</a></td>
-          <td class="nickname">코코볼의민족</td>
-          <td class="agent-name">김모찌</td>
-          <td class="button"><a class="btn btn-primary" role="button" id="client-manage">광고 관리</a></td>
-        </tr>
-        </tbody>
       </table>
-    </div>
-
-    <div class="row">
       <nav id="pagination" aria-label="Page navigation">
         <ul class="pagination justify-content-center">
           <li class="page-item"><a class="page-link" href="#">Previous</a></li>

--- a/src/main/resources/templates/manage/index.th.xml
+++ b/src/main/resources/templates/manage/index.th.xml
@@ -16,25 +16,40 @@
     </attr>
     <attr sel="#search-value" th:value="${param.searchValue}" />
 
+    <attr sel="#statistics_type_week" th:href="@{'/manage'(statisticsType=BEFORE_WEEK)}" th:method="get" />
+    <attr sel="#statistics_type_month" th:href="@{'/manage'(statisticsType=BEFORE_MONTH)}" th:method="get" />
+
+    <attr sel="#client-spend-statistics-info">
+        <attr sel="tbody" th:remove="all-but-first">
+          <attr sel="tr[0]" th:each="totalClientSpendStatistic : ${totalClientSpendStatistics}">
+            <attr sel="td.date" th:text="${totalClientSpendStatistic.startDate} + ' ~ ' + ${totalClientSpendStatistic.lastDate}" />
+            <attr sel="td.spend" th:text="${totalClientSpendStatistic.sSpend} + '원'" />
+          </attr>
+        </attr>
+      </attr>
+
     <attr sel="#client-table">
       <attr sel="thead/tr">
         <attr sel="th.user-id/a" th:text="'광고주 ID'" th:href="@{/manage(
       page=${clientUsers.number},
       sort='userId' + (*{sort.getOrderFor('userId')} != null ? (*{sort.getOrderFor('userId').direction.name} != 'DESC' ? ',desc' : '') : ''),
       searchType=${param.searchType},
-      searchValue=${param.searchValue}
+      searchValue=${param.searchValue},
+      statisticsType=${param.statisticsType}
   )}"/>
         <attr sel="th.nickname/a" th:text="'광고주명'" th:href="@{/manage(
       page=${clientUsers.number},
       sort='nickname' + (*{sort.getOrderFor('nickname')} != null ? (*{sort.getOrderFor('nickname').direction.name} != 'DESC' ? ',desc' : '') : ''),
       searchType=${param.searchType},
-      searchValue=${param.searchValue}
+      searchValue=${param.searchValue},
+      statisticsType=${param.statisticsType}
   )}"/>
         <attr sel="th.category/a" th:text="'업종'" th:href="@{/clients(
       page=${clientUsers.number},
       sort='categoryName' + (*{sort.getOrderFor('categoryName')} != null ? (*{sort.getOrderFor('categoryName').direction.name} != 'DESC' ? ',desc' : '') : ''),
       searchType=${param.searchType},
-      searchValue=${param.searchValue}
+      searchValue=${param.searchValue},
+      statisticsType=${param.statisticsType}
   )}"/>
       </attr>
 
@@ -52,19 +67,19 @@
     <attr sel="#pagination">
       <attr sel="li[0]/a"
             th:text="'previous'"
-            th:href="@{/manage(page=${clientUsers.number - 1}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
+            th:href="@{/manage(page=${clientUsers.number - 1}, searchType=${param.searchType}, searchValue=${param.searchValue}, statisticsType=${param.statisticsType})}"
             th:class="'page-link' + (${clientUsers.number} <= 0 ? ' disabled' : '')"
       />
       <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
         <attr sel="a"
               th:text="${pageNumber + 1}"
-              th:href="@{/manage(page=${pageNumber}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
+              th:href="@{/manage(page=${pageNumber}, searchType=${param.searchType}, searchValue=${param.searchValue}, statisticsType=${param.statisticsType})}"
               th:class="'page-link' + (${pageNumber} == ${clientUsers.number} ? ' disabled' : '')"
         />
       </attr>
       <attr sel="li[2]/a"
             th:text="'next'"
-            th:href="@{/manage(page=${clientUsers.number + 1}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
+            th:href="@{/manage(page=${clientUsers.number + 1}, searchType=${param.searchType}, searchValue=${param.searchValue}, statisticsType=${param.statisticsType})}"
             th:class="'page-link' + (${clientUsers.number} >= ${clientUsers.totalPages - 1} ? ' disabled' : '')"
       />
     </attr>


### PR DESCRIPTION
소재와 연결된 실적들에 대해 통계 기능이 구현되었으므로,
광고 관리 메인 페이지 (광고주 리스트 및 관리 페이지)에서 소재를 모아놓은 캠페인에 대한 통계 기능을 제공할 수 있도록 수정한다.

* [x] 통계 쿼리 작성 및 테스트 -> QueryDSL로 변환
* [x] 일일 통계 기능 구현
* [x] 최근 1주일 간의 통계 보기 기능 구현
* [x] 최근 30일 간의 통계 보기 기능 구현

This closes #112 