### PR TITLE
소재 도메인 수정 및 상세 정보 추가

### DIFF
--- a/src/main/generated/com/agencyplatformclonecoding/domain/QCreative.java
+++ b/src/main/generated/com/agencyplatformclonecoding/domain/QCreative.java
@@ -38,6 +38,8 @@ public class QCreative extends EntityPathBase<Creative> {
 
     public final BooleanPath deleted = createBoolean("deleted");
 
+    public final StringPath description = createString("description");
+
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
     public final StringPath keyword = createString("keyword");
@@ -49,6 +51,8 @@ public class QCreative extends EntityPathBase<Creative> {
     public final StringPath modifiedBy = _super.modifiedBy;
 
     public final SetPath<Performance, QPerformance> performances = this.<Performance, QPerformance>createSet("performances", Performance.class, QPerformance.class, PathInits.DIRECT2);
+
+    public final StringPath url = createString("url");
 
     public final NumberPath<Long> view = createNumber("view", Long.class);
 

--- a/src/main/java/com/agencyplatformclonecoding/domain/Creative.java
+++ b/src/main/java/com/agencyplatformclonecoding/domain/Creative.java
@@ -31,6 +31,8 @@ public class Creative extends AuditingFields {
 
     @Setter @Column private String keyword;
     @Setter @Column private Long bidingPrice;
+    @Setter @Column(length = 15) private String description;
+    @Setter @Column private String url;
     @Setter @Column private Long view;
 
     @ToString.Exclude
@@ -45,15 +47,17 @@ public class Creative extends AuditingFields {
     protected Creative() {
     }
 
-    private Creative(Campaign campaign, String keyword, Long bidingPrice) {
+    private Creative(Campaign campaign, String keyword, Long bidingPrice, String description, String url) {
         this.campaign = campaign;
         this.keyword = keyword;
         this.bidingPrice = bidingPrice;
+        this.description = description;
+        this.url = url;
         this.deleted = false;
     }
 
-    public static Creative of(Campaign campaign, String keyword, Long bidingPrice) {
-        return new Creative(campaign, keyword, bidingPrice);
+    public static Creative of(Campaign campaign, String keyword, Long bidingPrice, String description, String url) {
+        return new Creative(campaign, keyword, bidingPrice, description, url);
     }
 
     @Override

--- a/src/main/java/com/agencyplatformclonecoding/dto/CreativeDto.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/CreativeDto.java
@@ -13,6 +13,8 @@ public record CreativeDto(
         String keyword,
         Long bidingPrice,
         String sBidingPrice,
+        String description,
+        String url,
         LocalDateTime createdAt,
         String createdBy,
         LocalDateTime modifiedAt,
@@ -20,15 +22,15 @@ public record CreativeDto(
         boolean activated
 ) {
 
-    public static CreativeDto of(CampaignDto campaignDto, Long campaignId, String keyword, Long bidingPrice) {
+    public static CreativeDto of(CampaignDto campaignDto, Long campaignId, String keyword, Long bidingPrice, String description, String url) {
 
         String sBidingPrice = formatToString(bidingPrice);
 
-        return new CreativeDto(campaignDto, campaignId, null, keyword, bidingPrice, sBidingPrice, null, null, null, null, false);
+        return new CreativeDto(campaignDto, campaignId, null, keyword, bidingPrice, sBidingPrice, description, url, null, null, null, null, false);
     }
 
-    public static CreativeDto of(CampaignDto campaignDto, Long campaignId, Long id, String keyword, Long bidingPrice, String sBidingPrice, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy, boolean activated) {
-        return new CreativeDto(campaignDto, campaignId, id, keyword, bidingPrice, sBidingPrice, createdAt, createdBy, modifiedAt, modifiedBy, activated);
+    public static CreativeDto of(CampaignDto campaignDto, Long campaignId, Long id, String keyword, Long bidingPrice, String sBidingPrice, String description, String url, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy, boolean activated) {
+        return new CreativeDto(campaignDto, campaignId, id, keyword, bidingPrice, sBidingPrice, description, url, createdAt, createdBy, modifiedAt, modifiedBy, activated);
     }
 
     // Entity -> dto로 변환
@@ -43,6 +45,8 @@ public record CreativeDto(
                 entity.getKeyword(),
                 entity.getBidingPrice(),
                 sBidingPrice,
+                entity.getDescription(),
+                entity.getUrl(),
                 entity.getCreatedAt(),
                 entity.getCreatedBy(),
                 entity.getModifiedAt(),
@@ -56,7 +60,9 @@ public record CreativeDto(
         return Creative.of(
                 campaign,
                 keyword,
-                bidingPrice
+                bidingPrice,
+                description,
+                url
         );
     }
 

--- a/src/main/java/com/agencyplatformclonecoding/dto/CreativeWithPerformancesDto.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/CreativeWithPerformancesDto.java
@@ -15,6 +15,8 @@ public record CreativeWithPerformancesDto(
         String keyword,
         Long bidingPrice,
         String sBidingPrice,
+        String description,
+        String url,
         LocalDateTime createdAt,
         String createdBy,
         LocalDateTime modifiedAt,
@@ -23,8 +25,8 @@ public record CreativeWithPerformancesDto(
         boolean activated
 ) {
 
-    public static CreativeWithPerformancesDto of(CampaignDto campaignDto, Long campaignId, Long id, String keyword, Long bidingPrice, String sBidingPrice, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy, Set<PerformanceDto> performanceDtos, boolean activated) {
-        return new CreativeWithPerformancesDto(campaignDto, campaignId, id, keyword, bidingPrice, sBidingPrice, createdAt, createdBy, modifiedAt, modifiedBy, performanceDtos, activated);
+    public static CreativeWithPerformancesDto of(CampaignDto campaignDto, Long campaignId, Long id, String keyword, Long bidingPrice, String sBidingPrice, String description, String url, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy, Set<PerformanceDto> performanceDtos, boolean activated) {
+        return new CreativeWithPerformancesDto(campaignDto, campaignId, id, keyword, bidingPrice, sBidingPrice, description, url, createdAt, createdBy, modifiedAt, modifiedBy, performanceDtos, activated);
     }
 
     // Entity -> dto로 변환
@@ -39,6 +41,8 @@ public record CreativeWithPerformancesDto(
                 entity.getKeyword(),
                 entity.getBidingPrice(),
                 sBidingPrice,
+                entity.getDescription(),
+                entity.getUrl(),
                 entity.getCreatedAt(),
                 entity.getCreatedBy(),
                 entity.getModifiedAt(),

--- a/src/main/java/com/agencyplatformclonecoding/dto/request/CreativeRequest.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/request/CreativeRequest.java
@@ -6,11 +6,13 @@ import com.agencyplatformclonecoding.dto.CreativeDto;
 public record CreativeRequest(
         Long campaignId,
         String keyword,
-        Long bidingPrice
+        Long bidingPrice,
+        String description,
+        String url
 ) {
 
-    public static CreativeRequest of(Long campaignId, String keyword, Long bidingPrice) {
-        return new CreativeRequest(campaignId, keyword, bidingPrice);
+    public static CreativeRequest of(Long campaignId, String keyword, Long bidingPrice, String description, String url) {
+        return new CreativeRequest(campaignId, keyword, bidingPrice, description, url);
     }
 
     public CreativeDto toDto(CampaignDto campaignDto) {
@@ -18,7 +20,9 @@ public record CreativeRequest(
                 campaignDto,
                 campaignDto.id(),
                 keyword,
-                bidingPrice
+                bidingPrice,
+                description,
+                url
         );
     }
 }

--- a/src/main/java/com/agencyplatformclonecoding/dto/response/CreativeResponse.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/response/CreativeResponse.java
@@ -9,12 +9,14 @@ public record CreativeResponse(
         String keyword,
         Long bidingPrice,
         String sBidingPrice,
+        String description,
+        String url,
         Long campaignId,
         boolean activated
 ) implements Serializable {
 
-    public static CreativeResponse of(Long id, String keyword, Long bidingPrice, String sBidingPrice, Long campaignId, boolean activated) {
-        return new CreativeResponse(id, keyword, bidingPrice, sBidingPrice, campaignId, activated);
+    public static CreativeResponse of(Long id, String keyword, Long bidingPrice, String sBidingPrice, String description, String url, Long campaignId, boolean activated) {
+        return new CreativeResponse(id, keyword, bidingPrice, sBidingPrice, description, url, campaignId, activated);
     }
 
     public static CreativeResponse from(CreativeDto dto) {
@@ -26,6 +28,8 @@ public record CreativeResponse(
                 dto.keyword(),
                 dto.bidingPrice(),
                 dto.sBidingPrice(),
+                dto.description(),
+                dto.url(),
                 campaignId,
                 activated
         );

--- a/src/main/java/com/agencyplatformclonecoding/dto/response/CreativeWithPerformancesResponse.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/response/CreativeWithPerformancesResponse.java
@@ -13,13 +13,15 @@ public record CreativeWithPerformancesResponse(
         String keyword,
         Long bidingPrice,
         String sBidingPrice,
+        String description,
+        String url,
         Long campaignId,
         Set<PerformanceResponse> performanceResponses,
         boolean activated
 ) implements Serializable {
 
-    public static CreativeWithPerformancesResponse of(Long id, String keyword, Long bidingPrice, String sBidingPrice, Long campaignId, Set<PerformanceResponse> performanceResponses, boolean activated) {
-        return new CreativeWithPerformancesResponse(id, keyword, bidingPrice, sBidingPrice, campaignId, performanceResponses, activated);
+    public static CreativeWithPerformancesResponse of(Long id, String keyword, Long bidingPrice, String sBidingPrice, String description, String url, Long campaignId, Set<PerformanceResponse> performanceResponses, boolean activated) {
+        return new CreativeWithPerformancesResponse(id, keyword, bidingPrice, sBidingPrice, description, url, campaignId, performanceResponses, activated);
     }
 
     public static CreativeWithPerformancesResponse from(CreativeWithPerformancesDto dto) {
@@ -31,6 +33,8 @@ public record CreativeWithPerformancesResponse(
                 dto.keyword(),
                 dto.bidingPrice(),
                 dto.sBidingPrice(),
+                dto.description(),
+                dto.url(),
                 campaignId,
                 dto.performanceDtos().stream()
                         .map(PerformanceResponse::from)

--- a/src/main/java/com/agencyplatformclonecoding/service/CreativeService.java
+++ b/src/main/java/com/agencyplatformclonecoding/service/CreativeService.java
@@ -66,6 +66,14 @@ public class CreativeService {
                 if (dto.keyword() != null) {
                     creative.setKeyword(dto.keyword());
                 }
+            if (dto.description() != null) {
+                creative.setDescription(dto.description());
+
+            }
+            if (dto.url() != null) {
+                creative.setUrl(dto.url());
+            }
+
             creative.setBidingPrice(dto.bidingPrice());
         } catch (EntityNotFoundException e) {
             log.warn("소재를 수정하는데 필요한 정보를 찾을 수 없습니다. - dto : {}", e.getLocalizedMessage());

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -159,21 +159,21 @@ insert into campaign (client_id, created_at, created_by, modified_at, modified_b
 ('c40', '2021-09-28 20:24:46', 'Griff', '2022-02-01 14:01:53', 'Griff', 17917, '2021-09-28 20:24:46, 17917', false, false);
 
 -- 소재 관련 (14개)
-insert into creative (campaign_id, created_at, created_by, modified_at, modified_by, biding_price, keyword, activated, deleted) values
-(1, '2022-07-13 01:32:28', 'Karoline', '2021-10-26 02:46:03', 'Karoline', 7224, '강남핸드폰매장', true, false),
-(1, '2022-07-10 04:40:02', 'Ashien', '2022-07-08 09:18:39', 'Ashien', 4503, '서울핸드폰매장', true, false),
-(1, '2021-11-26 01:47:21', 'Flossie', '2022-01-29 02:01:15', 'Flossie', 5463, '핸드폰매장추천', false, false),
-(1, '2022-06-10 22:12:32', 'Tracey', '2022-07-01 08:11:24', 'Tracey', 8190, '핸드폰중고거래', false, false),
-(1, '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', 5423, '핸드폰중고판매', false, false),
-(1, '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', 5423, '중고핸드폰판매', false, false),
-(1, '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', 5423, '핸드폰저렴하게', false, false),
-(1, '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', 5423, '핸드폰견적', false, false),
-(1, '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', 5423, '강남핸드폰견적', false, false),
-(1, '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', 5423, '서울핸드폰견적', false, false),
-(1, '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', 5423, '저가형핸드폰', false, false),
-(2, '2022-07-13 01:32:28', 'Karoline', '2021-10-26 02:46:03', 'Karoline', 7224, '아이폰자급제', true, false),
-(2, '2022-07-10 04:40:02', 'Ashien', '2022-07-08 09:18:39', 'Ashien', 4503, '아이폰약정', true, false),
-(2, '2021-11-26 01:47:21', 'Flossie', '2022-01-29 02:01:15', 'Flossie', 5463, '아이폰색상추천', false, false);
+insert into creative (campaign_id, biding_price, keyword, description, url, created_at, created_by, modified_at, modified_by, activated, deleted) values
+(1, 7224, '강남핸드폰매장', '핸드폰 구매는 코코볼모바일', 'https://velog.io/@mrcocoball', '2022-07-13 01:32:28', 'Karoline', '2021-10-26 02:46:03', 'Karoline', true, false),
+(1, 4503, '서울핸드폰매장', '핸드폰 구매는 코코볼모바일', 'https://velog.io/@mrcocoball', '2022-07-10 04:40:02', 'Ashien', '2022-07-08 09:18:39', 'Ashien', true, false),
+(1, 5463, '핸드폰매장추천', '핸드폰 구매는 코코볼모바일', 'https://velog.io/@mrcocoball', '2021-11-26 01:47:21', 'Flossie', '2022-01-29 02:01:15', 'Flossie', false, false),
+(1, 8190, '핸드폰중고거래', '핸드폰 구매는 코코볼모바일', 'https://velog.io/@mrcocoball', '2022-06-10 22:12:32', 'Tracey', '2022-07-01 08:11:24', 'Tracey', false, false),
+(1, 5423, '핸드폰중고판매', '핸드폰 구매는 코코볼모바일', 'https://velog.io/@mrcocoball', '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', false, false),
+(1, 5423, '중고핸드폰판매', '핸드폰 구매는 코코볼모바일', 'https://velog.io/@mrcocoball', '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', false, false),
+(1, 5423, '핸드폰저렴하게', '핸드폰 구매는 코코볼모바일', 'https://velog.io/@mrcocoball', '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', false, false),
+(1, 5423, '핸드폰견적', '핸드폰 구매는 코코볼모바일', 'https://velog.io/@mrcocoball', '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', false, false),
+(1, 5423, '강남핸드폰견적', '핸드폰 구매는 코코볼모바일', 'https://velog.io/@mrcocoball', '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', false, false),
+(1, 5423, '서울핸드폰견적', '핸드폰 구매는 코코볼모바일', 'https://velog.io/@mrcocoball', '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', false, false),
+(1, 5423, '저가형핸드폰', '핸드폰 구매는 코코볼모바일', 'https://velog.io/@mrcocoball', '2022-03-31 01:00:20', 'Anders', '2022-06-08 12:58:18', 'Anders', false, false),
+(2, 7224, '아이폰자급제', '핸드폰 구매는 코코볼모바일', 'https://velog.io/@mrcocoball', '2022-07-13 01:32:28', 'Karoline', '2021-10-26 02:46:03', 'Karoline', true, false),
+(2, 4503, '아이폰약정', '핸드폰 구매는 코코볼모바일', 'https://velog.io/@mrcocoball', '2022-07-10 04:40:02', 'Ashien', '2022-07-08 09:18:39', 'Ashien', true, false),
+(2, 5463, '아이폰색상추천', '핸드폰 구매는 코코볼모바일', 'https://velog.io/@mrcocoball', '2021-11-26 01:47:21', 'Flossie', '2022-01-29 02:01:15', 'Flossie', false, false);
 
 -- 소재 실적 관련 (1개 소재, 31일치)
 insert into performance (creative_id, created_at, view, click, conversion, purchase, spend) values

--- a/src/main/resources/templates/agentgroups/form.th.xml
+++ b/src/main/resources/templates/agentgroups/form.th.xml
@@ -7,7 +7,7 @@
   <attr sel="#agentgroup-form-header/h1" th:text="${formStatus} ? '에이전트 그룹 ' + ${formStatus.description} : _" />
 
   <attr sel="#agentgroup-form" th:action="${formStatus?.update} ? '/agentGroups/' + ${agentGroup.id} + '/form' : '/agentGroups/form'" th:method="post">
-    <attr sel="#name" th:text="${agentGroup?.name} ?: _" />
+    <attr sel="#name" th:value="${agentGroup?.name} ?: _" />
     <attr sel="#submit-button" th:text="${formStatus?.description} ?: _" />
     <attr sel="#cancel-button" th:onclick="'history.back()'" />
   </attr>

--- a/src/main/resources/templates/manage/campaign-form.th.xml
+++ b/src/main/resources/templates/manage/campaign-form.th.xml
@@ -8,7 +8,7 @@
 
   <attr sel="#campaign-form" th:action="${formStatus?.update} ? '/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/form' : '/manage/' + ${clientUser.userId} + '/campaigns/form'" th:method="post">
     <attr sel="#name" th:value="${campaign?.name} ?: _" />
-    <attr sel="#budget" th:text="${campaign?.budget} ?: _" />
+    <attr sel="#budget" th:value="${campaign?.budget} ?: _" />
     <attr sel="#submit-button" th:text="${formStatus?.description} ?: _" />
     <attr sel="#cancel-button" th:onclick="'history.back()'" />
   </attr>

--- a/src/main/resources/templates/manage/creative-form.html
+++ b/src/main/resources/templates/manage/creative-form.html
@@ -62,15 +62,27 @@
 
     <form id="creative-form">
       <div class="row mb-3 justify-content-md-center">
-        <label for="keyword" class="col-sm-2 col-lg-1 col-form-label text-sm-end">키워드</label>
-        <div class="col-sm-8 col-lg-9">
+        <label for="keyword" class="col-sm-3 col-lg-3 col-form-label text-sm-end">키워드</label>
+        <div class="col-sm-7 col-lg-7">
           <input type="text" class="form-control" id="keyword" name="keyword" required>
         </div>
       </div>
       <div class="row mb-3 justify-content-md-center">
-        <label for="biding-price" class="col-sm-2 col-lg-1 col-form-label text-sm-end">입찰가</label>
-        <div class="col-sm-8 col-lg-9">
+        <label for="biding-price" class="col-sm-3 col-lg-3 col-form-label text-sm-end">입찰가</label>
+        <div class="col-sm-7 col-lg-7">
           <input type="text" class="form-control" id="biding-price" name="bidingPrice" required>
+        </div>
+      </div>
+      <div class="row mb-3 justify-content-md-center">
+        <label for="description" class="col-sm-3 col-lg-3 col-form-label text-sm-end">노출 문구 (15자 이하)</label>
+        <div class="col-sm-7 col-lg-7">
+          <input type="text" class="form-control" id="description" name="description" required>
+        </div>
+      </div>
+      <div class="row mb-3 justify-content-md-center">
+        <label for="url" class="col-sm-3 col-lg-3 col-form-label text-sm-end">랜딩 URL</label>
+        <div class="col-sm-7 col-lg-7">
+          <input type="text" class="form-control" id="url" name="url" required>
         </div>
       </div>
       <div class="row mb-5 justify-content-md-center">

--- a/src/main/resources/templates/manage/creative-form.th.xml
+++ b/src/main/resources/templates/manage/creative-form.th.xml
@@ -8,7 +8,9 @@
 
   <attr sel="#creative-form" th:action="${formStatus?.update} ? '/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives/' + ${creative.id} + '/form' : '/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives/form'" th:method="post">
     <attr sel="#keyword" th:value="${creative?.keyword} ?: _" />
-    <attr sel="#biding-price" th:text="${creative?.bidingPrice} ?: _" />
+    <attr sel="#biding-price" th:value="${creative?.bidingPrice} ?: _" />
+    <attr sel="#description" th:value="${creative?.description} ?: _" />
+    <attr sel="#url" th:value="${creative?.url} ?: _" />
     <attr sel="#submit-button" th:text="${formStatus?.description} ?: _" />
     <attr sel="#cancel-button" th:onclick="'history.back()'" />
   </attr>

--- a/src/main/resources/templates/manage/creative.html
+++ b/src/main/resources/templates/manage/creative.html
@@ -174,6 +174,8 @@
           <th class="id"><a>소재 번호</a></th>
           <th class="keyword"><a>소재 키워드</a></th>
           <th class="biding-price"><a>입찰가(원)</a></th>
+          <th class="description"><a>노출 문구</a></th>
+      		<th class="url"><a>URL</a></th>
           <th class="manage" colspan="3"><a></a></th>
         </tr>
         </thead>
@@ -188,29 +190,8 @@
           <td class="id">1</td>
           <td class="keyword">코코볼추천</td>
           <td class="biding-price">30000</td>
-          <td class="button"><a class="btn btn-primary" role="button" id="manage-creative">관리</a></td>
-          <td>
-            <form id="delete-creative-form">
-              <button class="btn btn-danger me-md-2" role="button" id="delete-creative">삭제</button>
-            </form>
-          </td>
-          <td class="button"><a class="btn btn-info" role="button" id="performance-info">성과 확인</a></td>
-        </tr>
-        <tr>
-          <td class="id">2</td>
-          <td class="keyword">코코볼구매</td>
-          <td class="biding-price">30000</td>
-          <td class="button"><a class="btn btn-primary" role="button" id="manage-creative">관리</a></td>
-          <td>
-            <form id="delete-creative-form">
-              <button class="btn btn-danger me-md-2" role="button" id="delete-creative">삭제</button>
-            </form>
-          </td>
-          <td class="button"><a class="btn btn-info" role="button" id="performance-info">성과 확인</a></td>
-        <tr>
-          <td class="id">3</td>
-          <td class="keyword">코코볼관리</td>
-          <td class="biding-price">30000</td>
+          <td class="description">맛있는 코코볼 추천해요</td>
+      		<td class="url"><a href="https://www.naver.com" target="_blank">URL 확인</a></td>
           <td class="button"><a class="btn btn-primary" role="button" id="manage-creative">관리</a></td>
           <td>
             <form id="delete-creative-form">

--- a/src/main/resources/templates/manage/creative.th.xml
+++ b/src/main/resources/templates/manage/creative.th.xml
@@ -53,6 +53,8 @@
           <attr sel="td.id" th:text="${creative.id}" />
           <attr sel="td.keyword" th:text="${creative.keyword}" />
           <attr sel="td.biding-price" th:text="${creative.sBidingPrice} + '원'" />
+          <attr sel="td.description" th:text="${creative.description}" />
+          <attr sel="td.url/a" th:href="${creative.url}" />
           <attr sel="#manage-creative" th:href="'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives/' + ${creative.id} + '/form'" />
           <attr sel="#delete-creative-form" th:action="'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives/' + ${creative.id} + '/delete'" th:method="post" />
           <attr sel="#performance-info" th:href="'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives/' + ${creative.id} + '/performances'"/>

--- a/src/main/resources/templates/manage/performance.html
+++ b/src/main/resources/templates/manage/performance.html
@@ -91,6 +91,8 @@
           <th class="id"><a>소재 번호</a></th>
           <th class="keyword"><a>소재 키워드</a></th>
           <th class="biding-price"><a>입찰가(원)</a></th>
+          <th class="description"><a>노출 문구</a></th>
+      		<th class="url"><a>URL</a></th>
         </tr>
         </thead>
         <tbody>
@@ -101,6 +103,8 @@
           <td class="id">1</td>
           <td class="keyword">코코볼추천</td>
           <td class="biding-price">30000</td>
+          <td class="description">맛있는 코코볼 추천해요</td>
+      		<td class="url"><a href="https://www.naver.com" target="_blank">URL 확인</a></td>
         </tr>
         </tbody>
       </table>

--- a/src/main/resources/templates/manage/performance.th.xml
+++ b/src/main/resources/templates/manage/performance.th.xml
@@ -18,6 +18,8 @@
       <attr sel="td.id" th:text="${creative.id}" />
       <attr sel="td.keyword" th:text="${creative.keyword}" />
       <attr sel="td.biding-price" th:text="${creative.sBidingPrice} + '원'"/>
+      <attr sel="td.description" th:text="${creative.description}" />
+      <attr sel="td.url/a" th:href="${creative.url}" />
     </attr>
   </attr>
 

--- a/src/test/java/com/agencyplatformclonecoding/fixture/Fixture.java
+++ b/src/test/java/com/agencyplatformclonecoding/fixture/Fixture.java
@@ -77,7 +77,9 @@ public class Fixture {
         Creative creative = Creative.of(
                 createCampaign(),
                 "t-keyword",
-                1000L
+                1000L,
+                "testDescription",
+                "testUrl"
         );
 
         return creative;
@@ -246,7 +248,9 @@ public class Fixture {
                 createCampaignDto(),
                 1L,
                 keyword,
-                1000L
+                1000L,
+                "testDescription",
+                "testUrl"
         );
     }
 
@@ -255,7 +259,9 @@ public class Fixture {
                 createCampaignDto(),
                 1L,
                 "t-creative",
-                bidingPrice
+                bidingPrice,
+                "testDescription",
+                "testUrl"
         );
     }
 


### PR DESCRIPTION
소재의 디테일한 정보를 추가하기 위해 도메인을 수정하고 페이지도 수정한다.
소재에 추가할 정보는 소재 Description, 랜딩 URL이다.
소재 Description의 길이는 1~15자이며, 랜딩 URL은 페이지 상에서는 'URL'로 표시하고 하이퍼링크로 대체할 예정.
캠페인 Mock Data의 이름도 수정한다.

* [x] ERD 수정
* [x] Mock Data 수정
* [x] 소재 도메인 수정
* [x] 소재 생성 / 수정 기능 변경
* [x] 소재 페이지 수정

This closes #113 