### PR TITLE
임의 기간 조회/통계 제공 기능 추가

### DIFF
--- a/src/main/java/com/agencyplatformclonecoding/controller/CampaignController.java
+++ b/src/main/java/com/agencyplatformclonecoding/controller/CampaignController.java
@@ -11,10 +11,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -98,12 +100,14 @@ public class CampaignController {
             @PathVariable Long campaignId,
             @PageableDefault(size = 5, sort = "activated", direction = Sort.Direction.DESC) Pageable pageable,
             @RequestParam(required = false) StatisticsType statisticsType,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate lastDate,
             ModelMap map
     ) {
         Page<CreativeResponse> creatives = creativeService.searchCreatives(pageable, campaignId, clientId).map(CreativeResponse::from);
-        Set<PerformanceStatisticsResponse> creativesStatistics = statisticsService.creativesWithPerformanceStatistics(statisticsType, campaignId)
+        Set<PerformanceStatisticsResponse> creativesStatistics = statisticsService.creativesWithPerformanceStatistics(startDate, lastDate, statisticsType, campaignId)
                 .stream().map(PerformanceStatisticsResponse::from).collect(Collectors.toCollection(LinkedHashSet::new));
-        Set<PerformanceStatisticsResponse> totalCreativesStatistics = statisticsService.totalCreativesPerformanceStatistics(statisticsType, campaignId)
+        Set<PerformanceStatisticsResponse> totalCreativesStatistics = statisticsService.totalCreativesPerformanceStatistics(startDate, lastDate, statisticsType, campaignId)
                 .stream().map(PerformanceStatisticsResponse::from).collect(Collectors.toCollection(LinkedHashSet::new));
         CampaignResponse campaign = CampaignResponse.from(campaignService.getCampaign(campaignId));
         ClientUserWithCampaignsResponse clientUserWithCampaignsResponse = ClientUserWithCampaignsResponse.from(manageService.getClientUserWithCampaigns(clientId));

--- a/src/main/java/com/agencyplatformclonecoding/controller/CreativeController.java
+++ b/src/main/java/com/agencyplatformclonecoding/controller/CreativeController.java
@@ -14,10 +14,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -125,14 +127,16 @@ public class CreativeController {
             @PathVariable("campaignId") Long campaignId,
             @PathVariable Long creativeId,
             @RequestParam(required = false) StatisticsType statisticsType,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate lastDate,
             @PageableDefault(size = 7, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             ModelMap map
     ) {
         CreativeWithPerformancesResponse creativeWithPerformancesResponse = CreativeWithPerformancesResponse.from(creativeService.getCreativeWithPerformances(creativeId));
         CampaignWithCreativesResponse campaignWithCreativesResponse = CampaignWithCreativesResponse.from(campaignService.getCampaignWithCreatives(campaignId));
         ClientUserWithCampaignsResponse clientUserWithCampaignsResponse = ClientUserWithCampaignsResponse.from(manageService.getClientUserWithCampaigns(clientId));
-        Page<PerformanceResponse> performances = performanceService.searchPerformances(pageable, statisticsType, creativeId, campaignId, clientId).map(PerformanceResponse::from);
-        Set<PerformanceStatisticsResponse> statistics = statisticsService.totalPerformanceStatistics(statisticsType, creativeId)
+        Page<PerformanceResponse> performances = performanceService.searchPerformances(pageable, startDate, lastDate, statisticsType, creativeId, campaignId, clientId).map(PerformanceResponse::from);
+        Set<PerformanceStatisticsResponse> statistics = statisticsService.totalPerformanceStatistics(startDate, lastDate, statisticsType, creativeId)
                 .stream().map(PerformanceStatisticsResponse::from).collect(Collectors.toCollection(LinkedHashSet::new));
         List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), performances.getTotalPages());
 

--- a/src/main/java/com/agencyplatformclonecoding/controller/ManageController.java
+++ b/src/main/java/com/agencyplatformclonecoding/controller/ManageController.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.time.LocalDate;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -40,12 +42,14 @@ public class ManageController {
             @RequestParam(required = false) SearchType searchType,
             @RequestParam(required = false) String searchValue,
             @RequestParam(required = false) StatisticsType statisticsType,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate lastDate,
             @PageableDefault(size = 10, sort = "userId", direction = Sort.Direction.ASC) Pageable pageable,
             ModelMap map
     ) {
         Page<ClientUserResponse> clientUsers = manageService.searchClientUsers(searchType, searchValue, pageable)
                 .map(ClientUserResponse::from);
-        Set<PerformanceStatisticsResponse> totalClientSpendStatistics = statisticsService.totalSpendStatistics(statisticsType)
+        Set<PerformanceStatisticsResponse> totalClientSpendStatistics = statisticsService.totalSpendStatistics(startDate, lastDate, statisticsType)
                 .stream().map(PerformanceStatisticsResponse::from).collect(Collectors.toCollection(LinkedHashSet::new));
         List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), clientUsers.getTotalPages());
 
@@ -61,13 +65,15 @@ public class ManageController {
     public String campaigns(
             @PathVariable String clientId,
             @RequestParam(required = false) StatisticsType statisticsType,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate lastDate,
             @PageableDefault(size = 5, sort = "activated", direction = Sort.Direction.DESC) Pageable pageable,
             ModelMap map
     ) {
         Page<CampaignResponse> campaigns = campaignService.searchCampaigns(pageable, clientId).map(CampaignResponse::from);
-        Set<PerformanceStatisticsResponse> campaignStatistics = statisticsService.clientWithCampaignsStatistics(statisticsType, clientId)
+        Set<PerformanceStatisticsResponse> campaignStatistics = statisticsService.clientWithCampaignsStatistics(startDate, lastDate, statisticsType, clientId)
                 .stream().map(PerformanceStatisticsResponse::from).collect(Collectors.toCollection(LinkedHashSet::new));
-        Set<PerformanceStatisticsResponse> totalCampaignStatistics = statisticsService.totalCampaignsPerformanceStatistics(statisticsType, clientId)
+        Set<PerformanceStatisticsResponse> totalCampaignStatistics = statisticsService.totalCampaignsPerformanceStatistics(startDate, lastDate, statisticsType, clientId)
                 .stream().map(PerformanceStatisticsResponse::from).collect(Collectors.toCollection(LinkedHashSet::new));
         ClientUserWithCampaignsResponse clientUserWithCampaigns = ClientUserWithCampaignsResponse.from(manageService.getClientUserWithCampaigns(clientId));
         List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), campaigns.getTotalPages());

--- a/src/main/java/com/agencyplatformclonecoding/domain/constrant/StatisticsType.java
+++ b/src/main/java/com/agencyplatformclonecoding/domain/constrant/StatisticsType.java
@@ -4,8 +4,7 @@ import lombok.Getter;
 
 public enum StatisticsType {
     BEFORE_WEEK("최근 7일"),
-    BEFORE_MONTH("최근 30일"),
-    BEFORE_CUSTOM("기간 설정");
+    BEFORE_MONTH("최근 30일");
 
     @Getter private final String description;
 

--- a/src/main/java/com/agencyplatformclonecoding/dto/response/ClientUserWithCampaignsResponse.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/response/ClientUserWithCampaignsResponse.java
@@ -13,11 +13,12 @@ public record ClientUserWithCampaignsResponse(
         String categoryName,
         LocalDateTime createdAt,
         String nickname,
+        String email,
         Set<CampaignResponse> campaignResponses
 ) implements Serializable {
 
-    public static ClientUserWithCampaignsResponse of(String userId, String categoryName, LocalDateTime createdAt, String nickname, Set<CampaignResponse> campaignResponses) {
-        return new ClientUserWithCampaignsResponse(userId, categoryName, createdAt, nickname, campaignResponses);
+    public static ClientUserWithCampaignsResponse of(String userId, String categoryName, LocalDateTime createdAt, String nickname, String email, Set<CampaignResponse> campaignResponses) {
+        return new ClientUserWithCampaignsResponse(userId, categoryName, createdAt, nickname, email, campaignResponses);
     }
 
     public static ClientUserWithCampaignsResponse from(ClientUserWithCampaignsDto dto) {
@@ -28,6 +29,7 @@ public record ClientUserWithCampaignsResponse(
                 categoryName,
                 dto.createdAt(),
                 dto.nickname(),
+                dto.email(),
                 dto.campaignDtos().stream()
                         .map(CampaignResponse::from)
                         .collect(Collectors.toCollection(LinkedHashSet::new))

--- a/src/main/java/com/agencyplatformclonecoding/service/PerformanceService.java
+++ b/src/main/java/com/agencyplatformclonecoding/service/PerformanceService.java
@@ -38,21 +38,29 @@ public class PerformanceService {
     }
 
     @Transactional(readOnly = true)
-    public Page<PerformanceDto> searchPerformances(Pageable pageable, StatisticsType statisticsType, Long creativeId, Long campaignId, String clientId) {
+    public Page<PerformanceDto> searchPerformances(Pageable pageable, LocalDate startDate, LocalDate lastDate, StatisticsType statisticsType, Long creativeId, Long campaignId, String clientId) {
+
         validateClientAndCampaignAndCreative(creativeId, campaignId, clientId);
-        LocalDate lastDate = LocalDate.parse(LocalDate.now().minusDays(1)
+        LocalDate defaultLastDate = LocalDate.parse(LocalDate.now().minusDays(1)
                 .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
-        LocalDate startDateBeforeSevenDays = lastDate.minusDays(6);
-        LocalDate startDateBeforeThirtyDays = lastDate.minusDays(30);
+        LocalDate startDateBeforeSevenDays = defaultLastDate.minusDays(6);
+        LocalDate startDateBeforeThirtyDays = defaultLastDate.minusDays(30);
+
+        if (startDate == null) {
+            startDate = startDateBeforeThirtyDays;
+        }
+
+        if (lastDate == null) {
+            lastDate = defaultLastDate;
+        }
 
         if (statisticsType == null) {
-            return performanceRepository.findByCreative_IdAndCreatedAtBetween(pageable, creativeId, startDateBeforeThirtyDays, lastDate).map(PerformanceDto::from);
+            return performanceRepository.findByCreative_IdAndCreatedAtBetween(pageable, creativeId, startDate, lastDate).map(PerformanceDto::from);
         }
 
         return switch (statisticsType) {
-            case BEFORE_WEEK -> performanceRepository.findByCreative_IdAndCreatedAtBetween(pageable, creativeId, startDateBeforeSevenDays, lastDate).map(PerformanceDto::from);
-            case BEFORE_MONTH -> performanceRepository.findByCreative_IdAndCreatedAtBetween(pageable, creativeId, startDateBeforeThirtyDays, lastDate).map(PerformanceDto::from);
-            case BEFORE_CUSTOM -> null;
+            case BEFORE_WEEK -> performanceRepository.findByCreative_IdAndCreatedAtBetween(pageable, creativeId, startDateBeforeSevenDays, defaultLastDate).map(PerformanceDto::from);
+            case BEFORE_MONTH -> performanceRepository.findByCreative_IdAndCreatedAtBetween(pageable, creativeId, startDateBeforeThirtyDays, defaultLastDate).map(PerformanceDto::from);
         };
     }
 

--- a/src/main/java/com/agencyplatformclonecoding/service/StatisticsService.java
+++ b/src/main/java/com/agencyplatformclonecoding/service/StatisticsService.java
@@ -21,116 +21,159 @@ public class StatisticsService {
     private final StatisticsQueryRepository statisticsQueryRepository;
 
     @Transactional(readOnly = true)
-    public List<PerformanceStatisticsDto> totalPerformanceStatistics(StatisticsType statisticsType, Long creativeId) {
+    public List<PerformanceStatisticsDto> totalPerformanceStatistics(LocalDate startDate, LocalDate lastDate, StatisticsType statisticsType, Long creativeId) {
 
-        LocalDate lastDate = LocalDate.parse(LocalDate.now().minusDays(1)
+        LocalDate defaultLastDate = LocalDate.parse(LocalDate.now().minusDays(1)
                 .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
-        LocalDate startDateBeforeSevenDays = lastDate.minusDays(6);
-        LocalDate startDateBeforeThirtyDays = lastDate.minusDays(30);
+        LocalDate startDateBeforeSevenDays = defaultLastDate.minusDays(6);
+        LocalDate startDateBeforeThirtyDays = defaultLastDate.minusDays(30);
+
+        if (lastDate == null) {
+            lastDate = defaultLastDate;
+        }
+
+        if (startDate == null) {
+            startDate = startDateBeforeThirtyDays;
+        }
 
         if (statisticsType == null) {
-            return statisticsQueryRepository.findByCreative_IdAndStatisticsDefault(creativeId, startDateBeforeThirtyDays, lastDate);
+            return statisticsQueryRepository.findByCreative_IdAndStatisticsDefault(creativeId, startDate, lastDate);
         }
 
         return switch (statisticsType) {
-            case BEFORE_WEEK -> statisticsQueryRepository.findByCreative_IdAndStatisticsDefault(creativeId, startDateBeforeSevenDays, lastDate);
-            case BEFORE_MONTH -> statisticsQueryRepository.findByCreative_IdAndStatisticsDefault(creativeId, startDateBeforeThirtyDays, lastDate);
-            case BEFORE_CUSTOM -> null;
+            case BEFORE_WEEK -> statisticsQueryRepository.findByCreative_IdAndStatisticsDefault(creativeId, startDateBeforeSevenDays, defaultLastDate);
+            case BEFORE_MONTH -> statisticsQueryRepository.findByCreative_IdAndStatisticsDefault(creativeId, startDateBeforeThirtyDays, defaultLastDate);
         };
     }
 
     @Transactional(readOnly = true)
-    public List<PerformanceStatisticsDto> creativesWithPerformanceStatistics(StatisticsType statisticsType, Long campaignId) {
+    public List<PerformanceStatisticsDto> creativesWithPerformanceStatistics(LocalDate startDate, LocalDate lastDate, StatisticsType statisticsType, Long campaignId) {
 
-        LocalDate lastDate = LocalDate.parse(LocalDate.now().minusDays(1)
+        LocalDate defaultLastDate = LocalDate.parse(LocalDate.now().minusDays(1)
                 .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
-        LocalDate startDateBeforeSevenDays = lastDate.minusDays(6);
-        LocalDate startDateBeforeThirtyDays = lastDate.minusDays(30);
+        LocalDate startDateBeforeSevenDays = defaultLastDate.minusDays(6);
+        LocalDate startDateBeforeThirtyDays = defaultLastDate.minusDays(30);
+
+
+        if (lastDate == null) {
+            lastDate = defaultLastDate;
+        }
+
+        if (startDate == null) {
+            startDate = startDateBeforeThirtyDays;
+        }
 
         if (statisticsType == null) {
-            return statisticsQueryRepository.findByCampaign_IdAndStatisticsDefault(campaignId, startDateBeforeThirtyDays, lastDate);
+            return statisticsQueryRepository.findByCampaign_IdAndStatisticsDefault(campaignId, startDate, lastDate);
         }
 
         return switch (statisticsType) {
-            case BEFORE_WEEK -> statisticsQueryRepository.findByCampaign_IdAndStatisticsDefault(campaignId, startDateBeforeSevenDays, lastDate);
-            case BEFORE_MONTH -> statisticsQueryRepository.findByCampaign_IdAndStatisticsDefault(campaignId, startDateBeforeThirtyDays, lastDate);
-            case BEFORE_CUSTOM -> null;
+            case BEFORE_WEEK -> statisticsQueryRepository.findByCampaign_IdAndStatisticsDefault(campaignId, startDateBeforeSevenDays, defaultLastDate);
+            case BEFORE_MONTH -> statisticsQueryRepository.findByCampaign_IdAndStatisticsDefault(campaignId, startDateBeforeThirtyDays, defaultLastDate);
         };
     }
 
     @Transactional(readOnly = true)
-    public List<PerformanceStatisticsDto> totalCreativesPerformanceStatistics(StatisticsType statisticsType, Long campaignId) {
+    public List<PerformanceStatisticsDto> totalCreativesPerformanceStatistics(LocalDate startDate, LocalDate lastDate, StatisticsType statisticsType, Long campaignId) {
 
-        LocalDate lastDate = LocalDate.parse(LocalDate.now().minusDays(1)
+        LocalDate defaultLastDate = LocalDate.parse(LocalDate.now().minusDays(1)
                 .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
-        LocalDate startDateBeforeSevenDays = lastDate.minusDays(6);
-        LocalDate startDateBeforeThirtyDays = lastDate.minusDays(30);
+        LocalDate startDateBeforeSevenDays = defaultLastDate.minusDays(6);
+        LocalDate startDateBeforeThirtyDays = defaultLastDate.minusDays(30);
+
+        if (lastDate == null) {
+            lastDate = defaultLastDate;
+        }
+
+        if (startDate == null) {
+            startDate = startDateBeforeThirtyDays;
+        }
 
         if (statisticsType == null) {
-            return statisticsQueryRepository.findByCampaign_IdAndTotalStatisticsDefault(campaignId, startDateBeforeThirtyDays, lastDate);
+            return statisticsQueryRepository.findByCampaign_IdAndTotalStatisticsDefault(campaignId, startDate, lastDate);
         }
 
         return switch (statisticsType) {
-            case BEFORE_WEEK -> statisticsQueryRepository.findByCampaign_IdAndTotalStatisticsDefault(campaignId, startDateBeforeSevenDays, lastDate);
-            case BEFORE_MONTH -> statisticsQueryRepository.findByCampaign_IdAndTotalStatisticsDefault(campaignId, startDateBeforeThirtyDays, lastDate);
-            case BEFORE_CUSTOM -> null;
+            case BEFORE_WEEK -> statisticsQueryRepository.findByCampaign_IdAndTotalStatisticsDefault(campaignId, startDateBeforeSevenDays, defaultLastDate);
+            case BEFORE_MONTH -> statisticsQueryRepository.findByCampaign_IdAndTotalStatisticsDefault(campaignId, startDateBeforeThirtyDays, defaultLastDate);
         };
     }
 
     @Transactional(readOnly = true)
-    public List<PerformanceStatisticsDto> clientWithCampaignsStatistics(StatisticsType statisticsType, String clientId) {
+    public List<PerformanceStatisticsDto> clientWithCampaignsStatistics(LocalDate startDate, LocalDate lastDate, StatisticsType statisticsType, String clientId) {
 
-        LocalDate lastDate = LocalDate.parse(LocalDate.now().minusDays(1)
+        LocalDate defaultLastDate = LocalDate.parse(LocalDate.now().minusDays(1)
                 .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
-        LocalDate startDateBeforeSevenDays = lastDate.minusDays(6);
-        LocalDate startDateBeforeThirtyDays = lastDate.minusDays(30);
+        LocalDate startDateBeforeSevenDays = defaultLastDate.minusDays(6);
+        LocalDate startDateBeforeThirtyDays = defaultLastDate.minusDays(30);
+
+        if (lastDate == null) {
+            lastDate = defaultLastDate;
+        }
+
+        if (startDate == null) {
+            startDate = startDateBeforeThirtyDays;
+        }
 
         if (statisticsType == null) {
-            return statisticsQueryRepository.findByClientUser_IdAndStatisticsDefault(clientId, startDateBeforeThirtyDays, lastDate);
+            return statisticsQueryRepository.findByClientUser_IdAndStatisticsDefault(clientId, startDate, lastDate);
         }
 
         return switch (statisticsType) {
-            case BEFORE_WEEK -> statisticsQueryRepository.findByClientUser_IdAndStatisticsDefault(clientId, startDateBeforeSevenDays, lastDate);
-            case BEFORE_MONTH -> statisticsQueryRepository.findByClientUser_IdAndStatisticsDefault(clientId, startDateBeforeThirtyDays, lastDate);
-            case BEFORE_CUSTOM -> null;
+            case BEFORE_WEEK -> statisticsQueryRepository.findByClientUser_IdAndStatisticsDefault(clientId, startDateBeforeSevenDays, defaultLastDate);
+            case BEFORE_MONTH -> statisticsQueryRepository.findByClientUser_IdAndStatisticsDefault(clientId, startDateBeforeThirtyDays, defaultLastDate);
         };
     }
 
     @Transactional(readOnly = true)
-    public List<PerformanceStatisticsDto> totalCampaignsPerformanceStatistics(StatisticsType statisticsType, String clientId) {
+    public List<PerformanceStatisticsDto> totalCampaignsPerformanceStatistics(LocalDate startDate, LocalDate lastDate, StatisticsType statisticsType, String clientId) {
 
-        LocalDate lastDate = LocalDate.parse(LocalDate.now().minusDays(1)
+        LocalDate defaultLastDate = LocalDate.parse(LocalDate.now().minusDays(1)
                 .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
-        LocalDate startDateBeforeSevenDays = lastDate.minusDays(6);
-        LocalDate startDateBeforeThirtyDays = lastDate.minusDays(30);
+        LocalDate startDateBeforeSevenDays = defaultLastDate.minusDays(6);
+        LocalDate startDateBeforeThirtyDays = defaultLastDate.minusDays(30);
+
+        if (lastDate == null) {
+            lastDate = defaultLastDate;
+        }
+
+        if (startDate == null) {
+            startDate = startDateBeforeThirtyDays;
+        }
 
         if (statisticsType == null) {
-            return statisticsQueryRepository.findByClientUser_IdAndTotalStatisticsDefault(clientId, startDateBeforeThirtyDays, lastDate);
+            return statisticsQueryRepository.findByClientUser_IdAndTotalStatisticsDefault(clientId, startDate, lastDate);
         }
 
         return switch (statisticsType) {
-            case BEFORE_WEEK -> statisticsQueryRepository.findByClientUser_IdAndTotalStatisticsDefault(clientId, startDateBeforeSevenDays, lastDate);
-            case BEFORE_MONTH -> statisticsQueryRepository.findByClientUser_IdAndTotalStatisticsDefault(clientId, startDateBeforeThirtyDays, lastDate);
-            case BEFORE_CUSTOM -> null;
+            case BEFORE_WEEK -> statisticsQueryRepository.findByClientUser_IdAndTotalStatisticsDefault(clientId, startDateBeforeSevenDays, defaultLastDate);
+            case BEFORE_MONTH -> statisticsQueryRepository.findByClientUser_IdAndTotalStatisticsDefault(clientId, startDateBeforeThirtyDays, defaultLastDate);
         };
     }
 
     @Transactional(readOnly = true)
-    public List<PerformanceStatisticsDto> totalSpendStatistics(StatisticsType statisticsType) {
+    public List<PerformanceStatisticsDto> totalSpendStatistics(LocalDate startDate, LocalDate lastDate, StatisticsType statisticsType) {
 
-        LocalDate lastDate = LocalDate.parse(LocalDate.now().minusDays(1)
+        LocalDate defaultLastDate = LocalDate.parse(LocalDate.now().minusDays(1)
                 .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
-        LocalDate startDateBeforeSevenDays = lastDate.minusDays(6);
-        LocalDate startDateBeforeThirtyDays = lastDate.minusDays(30);
+        LocalDate startDateBeforeSevenDays = defaultLastDate.minusDays(6);
+        LocalDate startDateBeforeThirtyDays = defaultLastDate.minusDays(30);
+
+        if (lastDate == null) {
+            lastDate = defaultLastDate;
+        }
+
+        if (startDate == null) {
+            startDate = startDateBeforeThirtyDays;
+        }
 
         if (statisticsType == null) {
-            return statisticsQueryRepository.findClientUserSpendTotalStatisticsDefault(startDateBeforeThirtyDays, lastDate);
+            return statisticsQueryRepository.findClientUserSpendTotalStatisticsDefault(startDate, lastDate);
         }
 
         return switch (statisticsType) {
-            case BEFORE_WEEK -> statisticsQueryRepository.findClientUserSpendTotalStatisticsDefault(startDateBeforeSevenDays, lastDate);
-            case BEFORE_MONTH -> statisticsQueryRepository.findClientUserSpendTotalStatisticsDefault(startDateBeforeThirtyDays, lastDate);
-            case BEFORE_CUSTOM -> null;
+            case BEFORE_WEEK -> statisticsQueryRepository.findClientUserSpendTotalStatisticsDefault(startDateBeforeSevenDays, defaultLastDate);
+            case BEFORE_MONTH -> statisticsQueryRepository.findClientUserSpendTotalStatisticsDefault(startDateBeforeThirtyDays, defaultLastDate);
         };
     }
 

--- a/src/main/resources/static/css/layout.css
+++ b/src/main/resources/static/css/layout.css
@@ -8,6 +8,11 @@ h1 {
     justify-content: space-between !important;
 }
 
+.justify-content-md-reverse {
+    justify-content: space-between !important;
+    flex-direction: row-reverse;
+}
+
 .container {
     width: 1080px;
     min-width: 1080px;
@@ -70,7 +75,17 @@ main {
 
 .create-btn {
     display: flex !important;
-    flex-direction: row-reverse;
+}
+
+.date-form {
+    display: flex !important;
+    width: 200px;
+    margin-right: 10px;
+    margin-left: 0px;
+}
+
+#statistics-date-form {
+    display: flex !important;
 }
 
 th, td {

--- a/src/main/resources/templates/manage/campaign.html
+++ b/src/main/resources/templates/manage/campaign.html
@@ -76,20 +76,27 @@
     </nav>
     <h1> 캠페인 관리 페이지 </h1>
 
-    <div class="row right">
+    <div class="row">
       <div class="create-btn d-grid gap-2 justify-content-md">
+        <form id="statistics-date-form" method="get">
+          <div class="date-form">
+            <input type="date" class="form-control" id="start-date" name="startDate", min="2020-01-01" />
+          </div>
+          <div class="date-form" >
+            <input type="date" class="form-control" id="last-date" name="lastDate" />
+          </div>
+            <button type="submit" class="stats-btn btn btn-primary" role="button" id="statistics_type_custom">통계 확인</button>
+        </form>
         <a class="stats-btn btn btn-primary" role="button" id="statistics_type_week">최근 7일간 통계</a>
         <a class="stats-btn btn btn-primary" role="button" id="statistics_type_month">최근 30일간 통계</a>
         <a class="btn btn-primary me-md-2" role="button" id="create-campaign">캠페인 생성</a>
       </div>
-    </div>
-
-    <div class="row">
       <table class="table" id="client-info">
         <thead>
         <tr>
           <th class="user-id col-xs-2"><a>광고주 ID</a></th>
           <th class="nickname col-xs-2"><a>광고주명</a></th>
+          <th class="email col-xs-2"><a>이메일</a></th>
           <th class="category col-xs-2"><a>업종</a></th>
         </tr>
         </thead>
@@ -97,6 +104,7 @@
         <tr>
           <td class="user-id"><a>client1</a></td>
           <td class="nickname">코코볼자동차</td>
+          <td class="email">client@client.com</td>
           <td class="category">자동차</td>
         </tr>
         </tbody>

--- a/src/main/resources/templates/manage/campaign.th.xml
+++ b/src/main/resources/templates/manage/campaign.th.xml
@@ -8,13 +8,17 @@
 
     <attr sel="#create-campaign" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/form'}"/>
 
+    <attr sel="#start-date" th:value="${param.startDate}" />
+    <attr sel="#last-date" th:value="${param.lastDate}" />
     <attr sel="#statistics_type_week" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(statisticsType=BEFORE_WEEK)}" th:method="get" />
     <attr sel="#statistics_type_month" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(statisticsType=BEFORE_MONTH)}" th:method="get" />
+    <attr sel="#statistics_type_custom" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(startDate=${param.startDate}, lastDate=${param.lastDate})}" th:method="get" />
 
     <attr sel="#client-info">
       <attr sel="tbody" th:remove="all-but-first">
         <attr sel="td.user-id" th:text="${clientUser.userId}" />
         <attr sel="td.nickname" th:text="${clientUser.nickname}" />
+        <attr sel="td.email" th:text="${clientUser.email}" />
         <attr sel="td.category" th:text="${clientUser.categoryName}"/>
       </attr>
     </attr>
@@ -61,12 +65,14 @@
         <attr sel="th.activate-status/a" th:text="'상태'" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(
       page=${campaigns.number},
       sort='activated' + (*{sort.getOrderFor('activated')} != null ? (*{sort.getOrderFor('activated').direction.name} != 'DESC' ? ',desc' : '') : ''),
-      statisticsType=${param.statisticsType}
+      statisticsType=${param.statisticsType},
+      startDate=${param.startDate}, lastDate=${param.lastDate}
   )}"/>
         <attr sel="th.budget/a" th:text="'예산'" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(
       page=${campaigns.number},
       sort='budget' + (*{sort.getOrderFor('budget')} != null ? (*{sort.getOrderFor('budget').direction.name} != 'DESC' ? ',desc' : '') : ''),
-      statisticsType=${param.statisticsType}
+      statisticsType=${param.statisticsType},
+      startDate=${param.startDate}, lastDate=${param.lastDate}
   )}"/>
       </attr>
 
@@ -88,19 +94,19 @@
     <attr sel="#pagination">
       <attr sel="li[0]/a"
             th:text="'previous'"
-            th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(page=${campaigns.number - 1}, statisticsType=${param.statisticsType})}"
+            th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(page=${campaigns.number - 1}, statisticsType=${param.statisticsType}, startDate=${param.startDate}, lastDate=${param.lastDate})}"
             th:class="'page-link' + (${campaigns.number} <= 0 ? ' disabled' : '')"
       />
       <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
         <attr sel="a"
               th:text="${pageNumber + 1}"
-              th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(page=${pageNumber}, statisticsType=${param.statisticsType})}"
+              th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(page=${pageNumber}, statisticsType=${param.statisticsType}, startDate=${param.startDate}, lastDate=${param.lastDate})}"
               th:class="'page-link' + (${pageNumber} == ${campaigns.number} ? ' disabled' : '')"
         />
       </attr>
       <attr sel="li[2]/a"
             th:text="'next'"
-            th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(page=${campaigns.number + 1}, statisticsType=${param.statisticsType})}"
+            th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns'(page=${campaigns.number + 1}, statisticsType=${param.statisticsType}, startDate=${param.startDate}, lastDate=${param.lastDate})}"
             th:class="'page-link' + (${campaigns.number} >= ${campaigns.totalPages - 1} ? ' disabled' : '')"
       />
     </attr>

--- a/src/main/resources/templates/manage/creative.html
+++ b/src/main/resources/templates/manage/creative.html
@@ -82,15 +82,21 @@
       <h1> 소재 관리 페이지 </h1>
     </header>
 
-    <div class="row right">
+    <div class="row">
       <div class="create-btn d-grid gap-2 justify-content-md">
+        <form id="statistics-date-form" method="get">
+          <div class="date-form">
+            <input type="date" class="form-control" id="start-date" name="startDate", min="2020-01-01" />
+          </div>
+          <div class="date-form" >
+            <input type="date" class="form-control" id="last-date" name="lastDate" />
+          </div>
+            <button type="submit" class="stats-btn btn btn-primary" role="button" id="statistics_type_custom">통계 확인</button>
+        </form>
         <a class="stats-btn btn btn-primary" role="button" id="statistics_type_week">최근 7일간 통계</a>
         <a class="stats-btn btn btn-primary" role="button" id="statistics_type_month">최근 30일간 통계</a>
         <a class="btn btn-primary me-md-2" role="button" id="create-creative">소재 생성</a>
       </div>
-    </div>
-
-    <div class="row">
       <table class="table" id="statistics-info">
         <thead>
         <tr>

--- a/src/main/resources/templates/manage/creative.th.xml
+++ b/src/main/resources/templates/manage/creative.th.xml
@@ -12,8 +12,11 @@
 
   <attr sel="#create-creative" th:href="'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives/form'" />
 
+  <attr sel="#start-date" th:value="${param.startDate}" />
+  <attr sel="#last-date" th:value="${param.lastDate}" />
   <attr sel="#statistics_type_week" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(statisticsType=BEFORE_WEEK)}" th:method="get" />
   <attr sel="#statistics_type_month" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(statisticsType=BEFORE_MONTH)}" th:method="get" />
+  <attr sel="#statistics_type_custom" th:action="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(startDate=${param.startDate}, lastDate=${param.lastDate})}" th:method="get" />
 
     <attr sel="#statistics-info">
         <attr sel="tbody" th:remove="all-but-first">
@@ -37,12 +40,14 @@
         <attr sel="th.activate-status/a" th:text="'상태'" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(
       page=${creatives.number},
       sort='activated' + (*{sort.getOrderFor('activated')} != null ? (*{sort.getOrderFor('activated').direction.name} != 'DESC' ? ',desc' : '') : ''),
-      statisticsType=${param.statisticsType}
+      statisticsType=${param.statisticsType},
+      startDate=${param.startDate}, lastDate=${param.lastDate}
   )}"/>
         <attr sel="th.biding-price/a" th:text="'입찰가'" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(
       page=${creatives.number},
       sort='bidingPrice' + (*{sort.getOrderFor('bidingPrice')} != null ? (*{sort.getOrderFor('bidingPrice').direction.name} != 'DESC' ? ',desc' : '') : ''),
-      statisticsType=${param.statisticsType}
+      statisticsType=${param.statisticsType},
+      startDate=${param.startDate}, lastDate=${param.lastDate}
   )}"/>
       </attr>
 
@@ -86,19 +91,19 @@
     <attr sel="#pagination">
       <attr sel="li[0]/a"
             th:text="'previous'"
-            th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(page=${creatives.number - 1}, statisticsType=${param.statisticsType})}"
+            th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(page=${creatives.number - 1}, statisticsType=${param.statisticsType}, startDate=${param.startDate}, lastDate=${param.lastDate})}"
             th:class="'page-link' + (${creatives.number} <= 0 ? ' disabled' : '')"
       />
       <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
         <attr sel="a"
               th:text="${pageNumber + 1}"
-              th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(page=${pageNumber}, statisticsType=${param.statisticsType})}"
+              th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(page=${pageNumber}, statisticsType=${param.statisticsType}, startDate=${param.startDate}, lastDate=${param.lastDate})}"
               th:class="'page-link' + (${pageNumber} == ${creatives.number} ? ' disabled' : '')"
         />
       </attr>
       <attr sel="li[2]/a"
             th:text="'next'"
-            th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(page=${creatives.number + 1}, statisticsType=${param.statisticsType})}"
+            th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives'(page=${creatives.number + 1}, statisticsType=${param.statisticsType}, startDate=${param.startDate}, lastDate=${param.lastDate})}"
             th:class="'page-link' + (${creatives.number} >= ${creatives.totalPages - 1} ? ' disabled' : '')"
       />
     </attr>

--- a/src/main/resources/templates/manage/index.html
+++ b/src/main/resources/templates/manage/index.html
@@ -106,12 +106,20 @@
       </div>
     </div>
 
-    <div class="row right">
+    <div class="row">
+      <div class="create-btn d-grid gap-2 justify-content-md">
+        <form id="statistics-date-form" method="get">
+          <div class="date-form">
+            <input type="date" class="form-control" id="start-date" name="startDate", min="2020-01-01" />
+          </div>
+          <div class="date-form" >
+            <input type="date" class="form-control" id="last-date" name="lastDate" />
+          </div>
+            <button type="submit" class="stats-btn btn btn-primary" role="button" id="statistics_type_custom">통계 확인</button>
+        </form>
         <a class="stats-btn btn btn-primary" role="button" id="statistics_type_week">최근 7일간 통계</a>
         <a class="stats-btn btn btn-primary" role="button" id="statistics_type_month">최근 30일간 통계</a>
-    </div>
-
-    <div class="row">
+      </div>
       <table class="table" id="client-spend-statistics-info">
         <thead>
         <tr>

--- a/src/main/resources/templates/manage/index.th.xml
+++ b/src/main/resources/templates/manage/index.th.xml
@@ -16,8 +16,11 @@
     </attr>
     <attr sel="#search-value" th:value="${param.searchValue}" />
 
+    <attr sel="#start-date" th:value="${param.startDate}" />
+    <attr sel="#last-date" th:value="${param.lastDate}" />
     <attr sel="#statistics_type_week" th:href="@{'/manage'(statisticsType=BEFORE_WEEK)}" th:method="get" />
     <attr sel="#statistics_type_month" th:href="@{'/manage'(statisticsType=BEFORE_MONTH)}" th:method="get" />
+    <attr sel="#statistics_type_custom" th:href="@{'/manage'(startDate=${param.startDate}, lastDate=${param.lastDate})}" th:method="get" />
 
     <attr sel="#client-spend-statistics-info">
         <attr sel="tbody" th:remove="all-but-first">
@@ -35,21 +38,24 @@
       sort='userId' + (*{sort.getOrderFor('userId')} != null ? (*{sort.getOrderFor('userId').direction.name} != 'DESC' ? ',desc' : '') : ''),
       searchType=${param.searchType},
       searchValue=${param.searchValue},
-      statisticsType=${param.statisticsType}
+      statisticsType=${param.statisticsType},
+      startDate=${param.startDate}, lastDate=${param.lastDate}
   )}"/>
         <attr sel="th.nickname/a" th:text="'광고주명'" th:href="@{/manage(
       page=${clientUsers.number},
       sort='nickname' + (*{sort.getOrderFor('nickname')} != null ? (*{sort.getOrderFor('nickname').direction.name} != 'DESC' ? ',desc' : '') : ''),
       searchType=${param.searchType},
       searchValue=${param.searchValue},
-      statisticsType=${param.statisticsType}
+      statisticsType=${param.statisticsType},
+      startDate=${param.startDate}, lastDate=${param.lastDate}
   )}"/>
         <attr sel="th.category/a" th:text="'업종'" th:href="@{/clients(
       page=${clientUsers.number},
       sort='categoryName' + (*{sort.getOrderFor('categoryName')} != null ? (*{sort.getOrderFor('categoryName').direction.name} != 'DESC' ? ',desc' : '') : ''),
       searchType=${param.searchType},
       searchValue=${param.searchValue},
-      statisticsType=${param.statisticsType}
+      statisticsType=${param.statisticsType},
+      startDate=${param.startDate}, lastDate=${param.lastDate}
   )}"/>
       </attr>
 
@@ -67,19 +73,19 @@
     <attr sel="#pagination">
       <attr sel="li[0]/a"
             th:text="'previous'"
-            th:href="@{/manage(page=${clientUsers.number - 1}, searchType=${param.searchType}, searchValue=${param.searchValue}, statisticsType=${param.statisticsType})}"
+            th:href="@{/manage(page=${clientUsers.number - 1}, searchType=${param.searchType}, searchValue=${param.searchValue}, statisticsType=${param.statisticsType}, startDate=${param.startDate}, lastDate=${param.lastDate})}"
             th:class="'page-link' + (${clientUsers.number} <= 0 ? ' disabled' : '')"
       />
       <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
         <attr sel="a"
               th:text="${pageNumber + 1}"
-              th:href="@{/manage(page=${pageNumber}, searchType=${param.searchType}, searchValue=${param.searchValue}, statisticsType=${param.statisticsType})}"
+              th:href="@{/manage(page=${pageNumber}, searchType=${param.searchType}, searchValue=${param.searchValue}, statisticsType=${param.statisticsType}, startDate=${param.startDate}, lastDate=${param.lastDate})}"
               th:class="'page-link' + (${pageNumber} == ${clientUsers.number} ? ' disabled' : '')"
         />
       </attr>
       <attr sel="li[2]/a"
             th:text="'next'"
-            th:href="@{/manage(page=${clientUsers.number + 1}, searchType=${param.searchType}, searchValue=${param.searchValue}, statisticsType=${param.statisticsType})}"
+            th:href="@{/manage(page=${clientUsers.number + 1}, searchType=${param.searchType}, searchValue=${param.searchValue}, statisticsType=${param.statisticsType}, startDate=${param.startDate}, lastDate=${param.lastDate})}"
             th:class="'page-link' + (${clientUsers.number} >= ${clientUsers.totalPages - 1} ? ' disabled' : '')"
       />
     </attr>

--- a/src/main/resources/templates/manage/performance.html
+++ b/src/main/resources/templates/manage/performance.html
@@ -84,6 +84,19 @@
     </header>
 
     <div class="row">
+      <div class="create-btn d-grid gap-2 justify-content-md">
+        <form id="statistics-date-form" method="get">
+          <div class="date-form">
+            <input type="date" class="form-control" id="start-date" name="startDate" , min="2020-01-01"/>
+          </div>
+          <div class="date-form">
+            <input type="date" class="form-control" id="last-date" name="lastDate"/>
+          </div>
+          <button type="submit" class="stats-btn btn btn-primary" role="button" id="statistics_type_custom">통계 확인</button>
+        </form>
+        <a class="stats-btn btn btn-primary" role="button" id="statistics_type_week">최근 7일간 통계</a>
+        <a class="stats-btn btn btn-primary" role="button" id="statistics_type_month">최근 30일간 통계</a>
+      </div>
       <table class="table" id="creative-info">
         <thead>
         <tr>
@@ -92,7 +105,7 @@
           <th class="keyword"><a>소재 키워드</a></th>
           <th class="biding-price"><a>입찰가(원)</a></th>
           <th class="description"><a>노출 문구</a></th>
-      		<th class="url"><a>URL</a></th>
+          <th class="url"><a>URL</a></th>
         </tr>
         </thead>
         <tbody>
@@ -104,49 +117,40 @@
           <td class="keyword">코코볼추천</td>
           <td class="biding-price">30000</td>
           <td class="description">맛있는 코코볼 추천해요</td>
-      		<td class="url"><a href="https://www.naver.com" target="_blank">URL 확인</a></td>
+          <td class="url"><a href="https://www.naver.com" target="_blank">URL 확인</a></td>
         </tr>
         </tbody>
       </table>
-
-      <div class="row right" style="margin-top: 50px">
-        <a class="stats-btn btn btn-primary" role="button" id="statistics_type_week">최근 7일간 통계</a>
-        <a class="stats-btn btn btn-primary" role="button" id="statistics_type_month">최근 30일간 통계</a>
-      </div>
-
-      <div class="row">
-        <table class="table" id="statistics-info">
-          <thead>
-          <tr>
-            <th class="date" style="width: 150px"><a>조회 기간</a></th>
-            <th class="view" style="width: 75px;"><a>총 노출수</a></th>
-            <th class="click" style="width: 75px;"><a>총 클릭수</a></th>
-            <th class="conversion" style="width: 75px;"><a>총 전환수</a></th>
-            <th class="purchase" style="width: 100px;"><a>총 구매액</a></th>
-            <th class="spend" style="width: 80px;"><a>총 소진액</a></th>
-            <th class="CTR" style="width: 75px;"><a>클릭률</a></th>
-            <th class="CVR" style="width: 75px;"><a>전환률</a></th>
-            <th class="CPA" style="width: 50px;"><a>CPA</a></th>
-            <th class="ROAS" style="width: 60px;"><a>ROAS</a></th>
-          </tr>
-          </thead>
-          <tbody>
-          <tr>
-            <td class="date"><a>2022-09-24 ~ 2022-10-24</a></td>
-            <td class="view"><a>1000</a></td>
-            <td class="click"><a>100</a></td>
-            <td class="conversion"><a>10</a></td>
-            <td class="purchase"><a>100000</a></td>
-            <td class="spend"><a>20000</a></td>
-            <td class="CTR"><a>0.1</a></td>
-            <td class="CVR"><a>0.1</a></td>
-            <td class="CPA"><a>2000</a></td>
-            <td class="ROAS"><a>500</a></td>
-          </tr>
-          </tbody>
-        </table>
-      </div>
-
+      <table class="table" id="statistics-info">
+        <thead>
+        <tr>
+          <th class="date" style="width: 150px"><a>조회 기간</a></th>
+          <th class="view" style="width: 75px;"><a>총 노출수</a></th>
+          <th class="click" style="width: 75px;"><a>총 클릭수</a></th>
+          <th class="conversion" style="width: 75px;"><a>총 전환수</a></th>
+          <th class="purchase" style="width: 100px;"><a>총 구매액</a></th>
+          <th class="spend" style="width: 80px;"><a>총 소진액</a></th>
+          <th class="CTR" style="width: 75px;"><a>클릭률</a></th>
+          <th class="CVR" style="width: 75px;"><a>전환률</a></th>
+          <th class="CPA" style="width: 50px;"><a>CPA</a></th>
+          <th class="ROAS" style="width: 60px;"><a>ROAS</a></th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <td class="date"><a>2022-09-24 ~ 2022-10-24</a></td>
+          <td class="view"><a>1000</a></td>
+          <td class="click"><a>100</a></td>
+          <td class="conversion"><a>10</a></td>
+          <td class="purchase"><a>100000</a></td>
+          <td class="spend"><a>20000</a></td>
+          <td class="CTR"><a>0.1</a></td>
+          <td class="CVR"><a>0.1</a></td>
+          <td class="CPA"><a>2000</a></td>
+          <td class="ROAS"><a>500</a></td>
+        </tr>
+        </tbody>
+      </table>
       <table class="table" id="performance-table" style="margin-top: 50px">
         <thead>
         <tr>

--- a/src/main/resources/templates/manage/performance.th.xml
+++ b/src/main/resources/templates/manage/performance.th.xml
@@ -23,8 +23,13 @@
     </attr>
   </attr>
 
+    <attr sel="#start-date" th:value="${param.startDate}" />
+    <attr sel="#last-date" th:value="${param.lastDate}" />
+
+
     <attr sel="#statistics_type_week" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives/' + ${creative.id} + '/performances'(statisticsType=BEFORE_WEEK)}" th:method="get" />
     <attr sel="#statistics_type_month" th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives/' + ${creative.id} + '/performances'(statisticsType=BEFORE_MONTH)}" th:method="get" />
+    <attr sel="#statistics_type_custom" th:action="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives/' + ${creative.id} + '/performances'(startDate=${param.startDate}, lastDate=${param.lastDate})}" th:method="get" />
 
     <attr sel="#statistics-info">
         <attr sel="tbody" th:remove="all-but-first">
@@ -63,19 +68,19 @@
     <attr sel="#pagination">
       <attr sel="li[0]/a"
             th:text="'previous'"
-            th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives/' + ${creative.id} + '/performances'(page=${performances.number - 1}, statisticsType=${param.statisticsType})}"
+            th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives/' + ${creative.id} + '/performances'(page=${performances.number - 1}, statisticsType=${param.statisticsType}, startDate=${param.startDate}, lastDate=${param.lastDate})}"
             th:class="'page-link' + (${performances.number} <= 0 ? ' disabled' : '')"
       />
       <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
         <attr sel="a"
               th:text="${pageNumber + 1}"
-              th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives/' + ${creative.id} + '/performances'(page=${pageNumber}, statisticsType=${param.statisticsType})}"
+              th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives/' + ${creative.id} + '/performances'(page=${pageNumber}, statisticsType=${param.statisticsType}, startDate=${param.startDate}, lastDate=${param.lastDate})}"
               th:class="'page-link' + (${pageNumber} == ${performances.number} ? ' disabled' : '')"
         />
       </attr>
       <attr sel="li[2]/a"
             th:text="'next'"
-            th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives/' + ${creative.id} + '/performances'(page=${performances.number + 1}, statisticsType=${param.statisticsType})}"
+            th:href="@{'/manage/' + ${clientUser.userId} + '/campaigns/' + ${campaign.id} + '/creatives/' + ${creative.id} + '/performances'(page=${performances.number + 1}, statisticsType=${param.statisticsType}, startDate=${param.startDate}, lastDate=${param.lastDate})}"
             th:class="'page-link' + (${performances.number} >= ${performances.totalPages - 1} ? ' disabled' : '')"
       />
     </attr>

--- a/src/test/java/com/agencyplatformclonecoding/service/PerformanceServiceTest.java
+++ b/src/test/java/com/agencyplatformclonecoding/service/PerformanceServiceTest.java
@@ -48,7 +48,7 @@ class PerformanceServiceTest {
         given(performanceRepository.findByCreative_IdAndCreatedAtBetween(pageable, creativeId, startDate, lastDate)).willReturn(Page.empty());
 
         // When
-        Page<PerformanceDto> performances = sut.searchPerformances(pageable, statisticsType, creativeId, campaignId, clientId);
+        Page<PerformanceDto> performances = sut.searchPerformances(pageable, startDate, lastDate, statisticsType, creativeId, campaignId, clientId);
 
         // Then
         assertThat(performances).isEmpty();


### PR DESCRIPTION
QueryDSL을 통해 Repository에서 처리하는 방법은 알고 있으나
페이지 영역에서 Request Parameter 값을 어떻게 받아야 할지 확인 필요할 것으로 보인다
캘린더 형식으로 받기에는 혼자서 작업하기가 불가능하므로 입력 방식으로 처리해야 할 것 같다
-> 확인 및 처리 완료 (코멘트 참조)

* [x] 기간 입력 칸 및 버튼 추가
* [x] 임의 기간 조회/통계 기능 추가

This closes #127 