### PR TITLE
대시보드 기능 구현 - 대행사 대시보드

### DIFF
--- a/src/main/java/com/agencyplatformclonecoding/controller/DashboardController.java
+++ b/src/main/java/com/agencyplatformclonecoding/controller/DashboardController.java
@@ -1,0 +1,93 @@
+package com.agencyplatformclonecoding.controller;
+
+import com.agencyplatformclonecoding.domain.constrant.ReportType;
+import com.agencyplatformclonecoding.dto.DashboardStatisticsDto;
+import com.agencyplatformclonecoding.service.DashboardService;
+import com.agencyplatformclonecoding.service.PaginationService;
+import com.agencyplatformclonecoding.service.ReportService;
+import com.agencyplatformclonecoding.service.StatisticsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import javax.servlet.http.HttpServletResponse;
+import java.time.LocalDate;
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("dashboard")
+@Controller
+public class DashboardController {
+
+    private final DashboardService dashboardService;
+    private final ReportService reportService;
+    private final PaginationService paginationService;
+
+    @GetMapping()
+    public String dashboard(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate lastDate,
+            Model model,
+            ModelMap map,
+            @PageableDefault(size = 10, sort = "startDate", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+
+        List<DashboardStatisticsDto> results = dashboardService.setTestDashboard(startDate, lastDate);
+        Page<DashboardStatisticsDto> resultpages = dashboardService.setTestDashboardTable(startDate, lastDate, pageable);
+        List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), resultpages.getTotalPages());
+
+        model.addAttribute("results", results);
+        model.addAttribute("resultpages", resultpages);
+        map.addAttribute("paginationBarNumbers", barNumbers);
+
+        return "dashboard/index";
+    }
+
+    @GetMapping("/clients")
+    public String dashboardClients(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate lastDate,
+            Model model,
+            ModelMap map,
+            @PageableDefault(size = 10, sort = "spend", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+
+        List<DashboardStatisticsDto> results = dashboardService.setTestDashboard2(startDate, lastDate);
+        Page<DashboardStatisticsDto> resultpages = dashboardService.setTestDashboardTable2(startDate, lastDate, pageable);
+        List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), resultpages.getTotalPages());
+
+        model.addAttribute("results", results);
+        model.addAttribute("resultpages", resultpages);
+        map.addAttribute("paginationBarNumbers", barNumbers);
+
+        return "dashboard/clients_top";
+    }
+
+    @GetMapping("/report")
+    public ResponseEntity totalSpendReport(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate lastDate,
+            HttpServletResponse response
+    ) {
+        return ResponseEntity.ok(reportService.getDashboardTotalSpendReport(response, startDate, lastDate));
+    }
+
+    @GetMapping("/clients/report")
+    public ResponseEntity clientsReport(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate lastDate,
+            HttpServletResponse response
+    ) {
+        return ResponseEntity.ok(reportService.getDashboardClientsSpendReport(response, startDate, lastDate));
+    }
+}

--- a/src/main/java/com/agencyplatformclonecoding/dto/DashboardStatisticsDto.java
+++ b/src/main/java/com/agencyplatformclonecoding/dto/DashboardStatisticsDto.java
@@ -1,0 +1,66 @@
+package com.agencyplatformclonecoding.dto;
+
+import lombok.Getter;
+
+import java.text.DecimalFormat;
+import java.time.LocalDate;
+
+@Getter
+public class DashboardStatisticsDto {
+
+    Long agentGroupId;
+    String agentGroupName;
+    String agentId;
+    String agentName;
+    String clientId;
+    String clientName;
+    String category;
+    Long spend;
+    String sSpend;
+    Long minusVAT;
+    String sMinusVAT;
+    Long VAT;
+    String sVAT;
+    Long commission;
+    String sCommission;
+    LocalDate startDate;
+    LocalDate lastDate;
+
+    public DashboardStatisticsDto() {
+    }
+
+    public void setSpendIndicator(Long spend) {
+
+        String sSpend = formatToString(spend);
+        Long VAT = spend / 10;
+        String sVAT = formatToString(VAT);
+        Long minusVAT = spend - VAT;
+        String sMinusVAT = formatToString(minusVAT);
+        Long commission = minusVAT * 15 / 100;
+        String sCommission = formatToString(commission);
+
+        this.sSpend = sSpend;
+        this.VAT = VAT;
+        this.sVAT = sVAT;
+        this.commission = commission;
+        this.sCommission = sCommission;
+        this.minusVAT = minusVAT;
+        this.sMinusVAT = sMinusVAT;
+    }
+
+    public void setStartDateAndLastDate(LocalDate startDate, LocalDate lastDate) {
+
+        this.startDate = startDate;
+        this.lastDate = lastDate;
+    }
+
+    public static String formatToString(Long amount) {
+        if (amount != null) {
+            DecimalFormat df = new DecimalFormat("###,###");
+            return df.format(amount);
+        }
+
+        return "0";
+    }
+
+}

--- a/src/main/java/com/agencyplatformclonecoding/service/DashboardService.java
+++ b/src/main/java/com/agencyplatformclonecoding/service/DashboardService.java
@@ -1,0 +1,113 @@
+package com.agencyplatformclonecoding.service;
+
+import com.agencyplatformclonecoding.dto.DashboardStatisticsDto;
+import com.agencyplatformclonecoding.repository.StatisticsQueryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class DashboardService {
+
+    private final StatisticsQueryRepository statisticsQueryRepository;
+
+    @Transactional(readOnly = true)
+    public List<DashboardStatisticsDto> setTestDashboard(LocalDate startDate, LocalDate lastDate) {
+
+        LocalDate defaultLastDate = LocalDate.parse(LocalDate.now().minusDays(1)
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        LocalDate startDateBeforeSevenDays = defaultLastDate.minusDays(6);
+        LocalDate startDateBeforeThirtyDays = defaultLastDate.minusDays(30);
+
+        if (lastDate == null) {
+            lastDate = defaultLastDate;
+        }
+
+        if (startDate == null) {
+            startDate = startDateBeforeThirtyDays;
+        }
+
+        return statisticsQueryRepository.dashboardTestQuery(startDate, lastDate).stream().limit(31).collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public Page<DashboardStatisticsDto> setTestDashboardTable(LocalDate startDate, LocalDate lastDate, Pageable pageable) {
+
+        LocalDate defaultLastDate = LocalDate.parse(LocalDate.now().minusDays(1)
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        LocalDate startDateBeforeSevenDays = defaultLastDate.minusDays(6);
+        LocalDate startDateBeforeThirtyDays = defaultLastDate.minusDays(30);
+
+        if (lastDate == null) {
+            lastDate = defaultLastDate;
+        }
+
+        if (startDate == null) {
+            startDate = startDateBeforeThirtyDays;
+        }
+
+        List<DashboardStatisticsDto> resultList = statisticsQueryRepository.dashboardTestQuery2(startDate, lastDate);
+        final int start = (int) pageable.getOffset();
+        final int end = Math.min((start + pageable.getPageSize()), resultList.size());
+        final Page<DashboardStatisticsDto> resultPage = new PageImpl<>(resultList.subList(start, end), pageable, resultList.size());
+
+        return resultPage;
+    }
+
+    // 상위 광고주별 소진액 차트 출력
+    @Transactional(readOnly = true)
+    public List<DashboardStatisticsDto> setTestDashboard2(LocalDate startDate, LocalDate lastDate) {
+
+        LocalDate defaultLastDate = LocalDate.parse(LocalDate.now().minusDays(1)
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        LocalDate startDateBeforeSevenDays = defaultLastDate.minusDays(6);
+        LocalDate startDateBeforeThirtyDays = defaultLastDate.minusDays(30);
+
+        if (lastDate == null) {
+            lastDate = defaultLastDate;
+        }
+
+        if (startDate == null) {
+            startDate = startDateBeforeThirtyDays;
+        }
+
+        return statisticsQueryRepository.dashboardTestQuery3(startDate, lastDate).stream().limit(10).collect(Collectors.toList());
+    }
+
+    // 전체 광고주별 소진액 차트 출력
+    @Transactional(readOnly = true)
+    public Page<DashboardStatisticsDto> setTestDashboardTable2(LocalDate startDate, LocalDate lastDate, Pageable pageable) {
+
+        LocalDate defaultLastDate = LocalDate.parse(LocalDate.now().minusDays(1)
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        LocalDate startDateBeforeSevenDays = defaultLastDate.minusDays(6);
+        LocalDate startDateBeforeThirtyDays = defaultLastDate.minusDays(30);
+
+        if (lastDate == null) {
+            lastDate = defaultLastDate;
+        }
+
+        if (startDate == null) {
+            startDate = startDateBeforeThirtyDays;
+        }
+
+        List<DashboardStatisticsDto> resultList = statisticsQueryRepository.dashboardTestQuery3(startDate, lastDate);
+        final int start = (int) pageable.getOffset();
+        final int end = Math.min((start + pageable.getPageSize()), resultList.size());
+        final Page<DashboardStatisticsDto> resultPage = new PageImpl<>(resultList.subList(start, end), pageable, resultList.size());
+
+        return resultPage;
+    }
+}

--- a/src/main/resources/static/css/layout.css
+++ b/src/main/resources/static/css/layout.css
@@ -31,6 +31,10 @@ h1 {
     margin-bottom: 30px;
 }
 
+.row > h1 {
+    margin-bottom: 30px;
+}
+
 .table {
     margin-top: 20px;
 }
@@ -71,6 +75,11 @@ main {
 
 #statistics-table > tbody {
     font-size: 11px
+}
+
+#dashboard-statistics-info > tbody {
+    font-size: 12px;
+    height: 85%;
 }
 
 .create-btn {

--- a/src/main/resources/templates/agentgroups/detail.html
+++ b/src/main/resources/templates/agentgroups/detail.html
@@ -48,7 +48,7 @@
           </a>
         </li>
         <li>
-          <a href="#" class="nav-link text-white">
+          <a href="/dashboard" class="nav-link text-white">
             <svg class="bi pe-none me-2" width="16" height="16"><use xlink:href="#people-circle"/></svg>
             대시보드
           </a>

--- a/src/main/resources/templates/agentgroups/form.html
+++ b/src/main/resources/templates/agentgroups/form.html
@@ -48,7 +48,7 @@
           </a>
         </li>
         <li>
-          <a href="#" class="nav-link text-white">
+          <a href="/dashboard" class="nav-link text-white">
             <svg class="bi pe-none me-2" width="16" height="16"><use xlink:href="#people-circle"/></svg>
             대시보드
           </a>

--- a/src/main/resources/templates/agentgroups/index.html
+++ b/src/main/resources/templates/agentgroups/index.html
@@ -59,7 +59,7 @@
         </a>
       </li>
       <li>
-        <a href="#" class="nav-link text-white">
+        <a href="/dashboard" class="nav-link text-white">
           <svg class="bi pe-none me-2" width="16" height="16">
             <use xlink:href="#people-circle"/>
           </svg>

--- a/src/main/resources/templates/agents/detail.html
+++ b/src/main/resources/templates/agents/detail.html
@@ -59,7 +59,7 @@
         </a>
       </li>
       <li>
-        <a href="#" class="nav-link text-white">
+        <a href="/dashboard" class="nav-link text-white">
           <svg class="bi pe-none me-2" width="16" height="16">
             <use xlink:href="#people-circle"/>
           </svg>

--- a/src/main/resources/templates/agents/index.html
+++ b/src/main/resources/templates/agents/index.html
@@ -48,7 +48,7 @@
           </a>
         </li>
         <li>
-          <a href="#" class="nav-link text-white">
+          <a href="/dashboard" class="nav-link text-white">
             <svg class="bi pe-none me-2" width="16" height="16"><use xlink:href="#people-circle"/></svg>
             대시보드
           </a>

--- a/src/main/resources/templates/clients/detail.html
+++ b/src/main/resources/templates/clients/detail.html
@@ -48,7 +48,7 @@
           </a>
         </li>
         <li>
-          <a href="#" class="nav-link text-white">
+          <a href="/dashboard" class="nav-link text-white">
             <svg class="bi pe-none me-2" width="16" height="16"><use xlink:href="#people-circle"/></svg>
             대시보드
           </a>

--- a/src/main/resources/templates/clients/index.html
+++ b/src/main/resources/templates/clients/index.html
@@ -59,7 +59,7 @@
         </a>
       </li>
       <li>
-        <a href="#" class="nav-link text-white">
+        <a href="/dashboard" class="nav-link text-white">
           <svg class="bi pe-none me-2" width="16" height="16">
             <use xlink:href="#people-circle"/>
           </svg>

--- a/src/main/resources/templates/dashboard/clients_top.html
+++ b/src/main/resources/templates/dashboard/clients_top.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <meta name="description" content="">
+  <meta name="author" content="mrcocoball">
+  <title>대시보드</title>
+
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+</head>
+
+<body>
+
+<header id="header">
+  헤더 삽입부
+  <hr>
+</header>
+
+<main class="d-flex flex-nowrap">
+  <div class="d-flex flex-column flex-shrink-0 p-3 text-bg-dark" style="min-height: 900px; width: 280px;">
+    <a href="/" class="d-flex align-items-center mb-0 mb-md-0 me-md-auto text-white text-decoration-none">
+      <svg class="bi pe-none me-2" width="40" height="32">
+        <use xlink:href="#bootstrap"/>
+      </svg>
+      <span class="fs-4"></span>
+    </a>
+    <ul class="nav nav-pills flex-column mb-auto">
+      <li class="nav-item">
+        <a href="/agents" class="nav-link text-white">
+          <svg class="bi pe-none me-2" width="16" height="16">
+            <use xlink:href="#home"/>
+          </svg>
+          에이전트 관리
+        </a>
+      </li>
+      <li>
+        <a href="/agentGroups" class="nav-link text-white">
+          <svg class="bi pe-none me-2" width="16" height="16">
+            <use xlink:href="#speedometer2"/>
+          </svg>
+          에이전트 그룹 관리
+        </a>
+      </li>
+      <li>
+        <a href="/clients" class="nav-link text-white">
+          <svg class="bi pe-none me-2" width="16" height="16">
+            <use xlink:href="#table"/>
+          </svg>
+          광고주 관리
+        </a>
+      </li>
+      <li>
+        <a href="/manage" class="nav-link text-white">
+          <svg class="bi pe-none me-2" width="16" height="16">
+            <use xlink:href="#grid"/>
+          </svg>
+          광고 관리
+        </a>
+      </li>
+      <li>
+        <a href="/dashboard" class="nav-link active" aria-current="page">
+          <svg class="bi pe-none me-2" width="16" height="16">
+            <use xlink:href="#people-circle"/>
+          </svg>
+          대시보드
+        </a>
+      </li>
+  </div>
+
+  <div class="container">
+    <div class="row">
+      <ul class="nav nav-pills">
+        <li class="nav-item">
+          <a class="nav-link disabled">대행사 대시보드</a>
+        </li>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">그룹-에이전트 대시보드</a>
+          <ul class="dropdown-menu">
+            <li><a class="dropdown-item" href="/dashboard/groups">그룹별 소진액</a></li>
+            <li><a class="dropdown-item" href="/dashboard/agents">에이전트별 소진액</a></li>
+          </ul>
+        </li>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">업종별 대시보드</a>
+          <ul class="dropdown-menu">
+            <li><a class="dropdown-item" href="/dashboard/category">업종별 소진액</a></li>
+            <li><a class="dropdown-item" href="/dashboard/category_clients">업종-광고주별 소진액</a></li>
+          </ul>
+        </li>
+      </ul>
+      <h1> 대시보드 </h1>
+    </div>
+
+    <div class="row">
+      <div class="create-btn d-grid gap-2 justify-content-md">
+        <form id="statistics-date-form" method="get">
+          <div class="date-form">
+            <input type="date" class="form-control" id="start-date" name="startDate" , min="2020-01-01"/>
+          </div>
+          <div class="date-form">
+            <input type="date" class="form-control" id="last-date" name="lastDate"/>
+          </div>
+          <button type="submit" class="stats-btn btn btn-primary" role="button" id="statistics_type_custom">통계 확인</button>
+          <a class="stats-btn btn btn-primary" role="button" id="default_dashboard">일일 소진액 대시보드</a>
+          <a class="stats-btn btn btn-primary" role="button" id="client_top_20_dashboard">광고주별 소진액 대시보드</a>
+          <a class="stats-btn btn btn-primary" role="button" id="get-report">보고서 다운로드</a>
+        </form>
+      </div>
+
+      <canvas id="myChart" height="175" width="600"></canvas>
+      <table class="table" id="dashboard-statistics-info">
+        <thead>
+        <tr>
+          <th class="date" style="width: 70px;"><a>조회 기간</a></th>
+          <th class="client_id" style="width: 50px;"><a>광고주 ID</a></th>
+          <th class="client_name" style="width: 50px;"><a>광고주명</a></th>
+          <th class="category" style="width: 50px;"><a>업종</a></th>
+          <th class="spend" style="width: 70px;"><a>총 소진액(VAT 포함)</a></th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <td class="date"><a>2022-09-24 ~ 2022-10-24</a></td>
+          <td class="client_id"><a></a></td>
+          <td class="client_name"><a></a></td>
+          <td class="category"><a></a></td>
+          <td class="spend"><a>22000</a></td>
+        </tr>
+        </tbody>
+      </table>
+      <nav id="pagination" aria-label="Page navigation">
+        <ul class="pagination justify-content-center">
+          <li class="page-item"><a class="page-link" href="#">Previous</a></li>
+          <li class="page-item"><a class="page-link" href="#">1</a></li>
+          <li class="page-item"><a class="page-link" href="#">Next</a></li>
+        </ul>
+      </nav>
+    </div>
+</main>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.6.1.js"
+        integrity="sha256-3zlB5s2uwoUzrXK3BT7AX3FyvojsraNFxCc2vC/7pNI="
+        crossorigin="anonymous"></script>
+
+<script type="text/javascript" th:inline="javascript">
+    /*<![CDATA[*/
+    $(document).ready(function () {
+        var nameList = [];
+        var spendList = [];
+
+        var data = /*[[ ${results} ]]*/[];
+        for (var i = 0; i < data.length; i++) {
+            nameList.push(data[i].clientName);
+            spendList.push(data[i].spend);
+        }
+        const ctx = document.getElementById('myChart').getContext('2d');
+        const chart = new Chart(ctx, {
+            type: 'bar', //chart 타입
+            data: {
+                labels: nameList,
+                datasets: [{
+                    fill: false,
+                    data: spendList,
+                    backgroundColor: [
+                        'rgb(95,192,153)',
+                    ],
+                    borderColor: [
+                        'rgba(125,134,173,0)',
+                    ],
+                    borderWidth: 1,
+                    barPercentage: 0.5
+                }]
+            },
+            options: {
+                plugins: {
+                    legend: {
+                        display: false
+                    },
+                },
+                scales: {
+                    y: {
+                        grid: {
+                            drawOnChartArea: true,  //선 지우기
+                            drawTicks: false,   //축의 숫자 옆 눈금 지우기
+                            drawBorder: true,
+                            borderDash: [3, 3]	//y축 선 실선으로 길이 3,간격 3으로
+                        },
+                        ticks: {
+                            padding: 10,
+                            beginAtZero: true,
+                            autoSkip: true,
+                            maxTicksLimit: 10
+                        }
+                    },
+                    x: {
+                        grid: {
+                            display: false,
+                            drawBorder: false,
+                            drawTicks: false
+                        },
+                        ticks: {
+                            padding: 10,
+                            font: {
+                                size: 9
+                            },
+                            autoSkip: true, // x축 데이터 갯수 제한
+                            maxTicksLimit: 10 // x축 데이터 갯수 제한
+                        }
+                    }
+                }
+            }
+        });
+    });
+    /*]]>*/
+
+</script>
+</th:block>
+
+</main>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-A3rJD856KowSb7dwlZdYEkO39Gagi7vIsF0jrRAoQmDKKtQBHUuLZ9AsSv4jD4Xa"
+        crossorigin="anonymous"></script>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
+
+</body>

--- a/src/main/resources/templates/dashboard/clients_top.th.xml
+++ b/src/main/resources/templates/dashboard/clients_top.th.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<thlogic>
+  <attr sel="head" th:replace="head :: head" />
+  <attr sel="#header" th:replace="header :: header" />
+  <attr sel="#footer" th:replace="footer :: footer" />
+
+  <attr sel="#start-date" th:value="${param.startDate}" />
+  <attr sel="#last-date" th:value="${param.lastDate}" />
+  <attr sel="#statistics_type_custom" th:href="@{'/dashboard/clientsTop'(startDate=${param.startDate}, lastDate=${param.lastDate})}" th:method="get" />
+  <attr sel="#default_dashboard" th:href="@{'/dashboard'(startDate=${param.startDate}, lastDate=${param.lastDate})}" th:method="get" />
+  <attr sel="#client_top_20_dashboard" th:href="@{'/dashboard/clients'(startDate=${param.startDate}, lastDate=${param.lastDate})}" th:method="get" />
+  <attr sel="#get-report" th:href="@{'/dashboard/clients/report'(startDate=${param.startDate}, lastDate=${param.lastDate})}" th:method="get" />
+
+  <attr sel="#dashboard-statistics-info">
+      <attr sel="tbody" th:remove="all-but-first">
+        <attr sel="tr[0]" th:each="resultpage : ${resultpages}">
+          <attr sel="td.date" th:text="${resultpage.startDate} + ' ~ ' + ${resultpage.lastDate}" />
+		  <attr sel="td.client_id" th:text="${resultpage.clientId}" />
+		  <attr sel="td.client_name" th:text="${resultpage.clientName}" />
+		  <attr sel="td.category" th:text="${resultpage.category}" />
+          <attr sel="td.spend" th:text="${resultpage.sSpend} + '원'" />
+        </attr>
+      </attr>
+    </attr>
+
+  <attr sel="#pagination">
+    <attr sel="li[0]/a"
+          th:text="'previous'"
+          th:href="@{/dashboard/clients(page=${resultpages.number - 1}, startDate=${param.startDate}, lastDate=${param.lastDate})}"
+          th:class="'page-link' + (${resultpages.number} <= 0 ? ' disabled' : '')"
+    />
+    <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
+      <attr sel="a"
+            th:text="${pageNumber + 1}"
+            th:href="@{/dashboard/clients(page=${pageNumber}, startDate=${param.startDate}, lastDate=${param.lastDate})}"
+            th:class="'page-link' + (${pageNumber} == ${resultpages.number} ? ' disabled' : '')"
+      />
+    </attr>
+    <attr sel="li[2]/a"
+          th:text="'next'"
+          th:href="@{/dashboard/clients(page=${resultpages.number + 1}, startDate=${param.startDate}, lastDate=${param.lastDate})}"
+          th:class="'page-link' + (${resultpages.number} >= ${resultpages.totalPages - 1} ? ' disabled' : '')"
+    />
+  </attr>
+</attr>
+</thlogic>

--- a/src/main/resources/templates/dashboard/index.html
+++ b/src/main/resources/templates/dashboard/index.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <meta name="description" content="">
+  <meta name="author" content="mrcocoball">
+  <title>대시보드</title>
+
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+</head>
+
+<body>
+
+<header id="header">
+  헤더 삽입부
+  <hr>
+</header>
+
+<main class="d-flex flex-nowrap">
+  <div class="d-flex flex-column flex-shrink-0 p-3 text-bg-dark" style="min-height: 900px; width: 280px;">
+    <a href="/" class="d-flex align-items-center mb-0 mb-md-0 me-md-auto text-white text-decoration-none">
+      <svg class="bi pe-none me-2" width="40" height="32">
+        <use xlink:href="#bootstrap"/>
+      </svg>
+      <span class="fs-4"></span>
+    </a>
+    <ul class="nav nav-pills flex-column mb-auto">
+      <li class="nav-item">
+        <a href="/agents" class="nav-link text-white">
+          <svg class="bi pe-none me-2" width="16" height="16">
+            <use xlink:href="#home"/>
+          </svg>
+          에이전트 관리
+        </a>
+      </li>
+      <li>
+        <a href="/agentGroups" class="nav-link text-white">
+          <svg class="bi pe-none me-2" width="16" height="16">
+            <use xlink:href="#speedometer2"/>
+          </svg>
+          에이전트 그룹 관리
+        </a>
+      </li>
+      <li>
+        <a href="/clients" class="nav-link text-white">
+          <svg class="bi pe-none me-2" width="16" height="16">
+            <use xlink:href="#table"/>
+          </svg>
+          광고주 관리
+        </a>
+      </li>
+      <li>
+        <a href="/manage" class="nav-link text-white">
+          <svg class="bi pe-none me-2" width="16" height="16">
+            <use xlink:href="#grid"/>
+          </svg>
+          광고 관리
+        </a>
+      </li>
+      <li>
+        <a href="/dashboard" class="nav-link active" aria-current="page">
+          <svg class="bi pe-none me-2" width="16" height="16">
+            <use xlink:href="#people-circle"/>
+          </svg>
+          대시보드
+        </a>
+      </li>
+  </div>
+
+  <div class="container">
+    <div class="row">
+      <ul class="nav nav-pills">
+        <li class="nav-item dropdown">
+          <a class="nav-link disabled">대행사 대시보드</a>
+        </li>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">그룹-에이전트 대시보드</a>
+          <ul class="dropdown-menu">
+            <li><a class="dropdown-item" href="/dashboard/groups">그룹별 소진액</a></li>
+            <li><a class="dropdown-item" href="/dashboard/agents">에이전트별 소진액</a></li>
+          </ul>
+        </li>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">업종별 대시보드</a>
+          <ul class="dropdown-menu">
+            <li><a class="dropdown-item" href="/dashboard/category">업종별 소진액</a></li>
+            <li><a class="dropdown-item" href="/dashboard/category_clients">업종-광고주별 소진액</a></li>
+          </ul>
+        </li>
+      </ul>
+      <h1> 대시보드 </h1>
+    </div>
+
+    <div class="row">
+      <div class="create-btn d-grid gap-2 justify-content-md">
+        <form id="statistics-date-form" method="get">
+          <div class="date-form">
+            <input type="date" class="form-control" id="start-date" name="startDate" , min="2020-01-01"/>
+          </div>
+          <div class="date-form">
+            <input type="date" class="form-control" id="last-date" name="lastDate"/>
+          </div>
+          <button type="submit" class="stats-btn btn btn-primary" role="button" id="statistics_type_custom">통계 확인
+          </button>
+          <a class="stats-btn btn btn-primary" role="button" id="default_dashboard">일일 소진액 대시보드</a>
+          <a class="stats-btn btn btn-primary" role="button" id="client_top_20_dashboard">광고주별 소진액 대시보드</a>
+          <a class="stats-btn btn btn-primary" role="button" id="get-report">보고서 다운로드</a>
+        </form>
+      </div>
+
+      <canvas id="myChart" height="175" width="600"></canvas>
+      <table class="table" id="dashboard-statistics-info">
+        <thead>
+        <tr>
+          <th class="date" style="width: 70px;"><a>조회 기간</a></th>
+          <th class="spend" style="width: 70px;"><a>총 소진액(VAT 포함)</a></th>
+          <th class="minusVAT" style="width: 70px;"><a>총 소진액(VAT 미포함)</a></th>
+          <th class="VAT" style="width: 70px;"><a>VAT</a></th>
+          <th class="commission" style="width: 70px"><a>대행 수수료</a></th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <td class="date"><a>2022-09-24 ~ 2022-10-24</a></td>
+          <td class="spend"><a>22000</a></td>
+          <td class="minusVAT"><a>20000</a></td>
+          <td class="VAT"><a>2000</a></td>
+          <td class="commission"><a></a>30</td>
+        </tr>
+        </tbody>
+      </table>
+      <nav id="pagination" aria-label="Page navigation">
+        <ul class="pagination justify-content-center">
+          <li class="page-item"><a class="page-link" href="#">Previous</a></li>
+          <li class="page-item"><a class="page-link" href="#">1</a></li>
+          <li class="page-item"><a class="page-link" href="#">Next</a></li>
+        </ul>
+      </nav>
+    </div>
+</main>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.6.1.js"
+        integrity="sha256-3zlB5s2uwoUzrXK3BT7AX3FyvojsraNFxCc2vC/7pNI="
+        crossorigin="anonymous"></script>
+
+<script type="text/javascript" th:inline="javascript">
+    /*<![CDATA[*/
+    $(document).ready(function () {
+        var dayList = [];
+        var spendList = [];
+
+        var data = /*[[ ${results} ]]*/[];
+        for (var i = 0; i < data.length; i++) {
+            dayList.push(data[i].startDate);
+            spendList.push(data[i].spend);
+        }
+        const ctx = document.getElementById('myChart').getContext('2d');
+        const chart = new Chart(ctx, {
+            type: 'bar', //chart 타입
+            data: {
+                labels: dayList,
+                datasets: [{
+                    fill: false,
+                    data: spendList,
+                    backgroundColor: [
+                        'rgb(95,192,153)',
+                    ],
+                    borderColor: [
+                        'rgba(125,134,173,0)',
+                    ],
+                    borderWidth: 1,
+                    barPercentage: 0.5
+                }]
+            },
+            options: {
+                plugins: {
+                    legend: {
+                        display: false
+                    },
+                },
+                scales: {
+                    y: {
+                        grid: {
+                            drawOnChartArea: true,  //선 지우기
+                            drawTicks: false,   //축의 숫자 옆 눈금 지우기
+                            drawBorder: true,
+                            borderDash: [3, 3]	//y축 선 실선으로 길이 3,간격 3으로
+                        },
+                        ticks: {
+                            padding: 10,
+                            beginAtZero: true
+                        }
+                    },
+                    x: {
+                        grid: {
+                            display: false,
+                            drawBorder: false,
+                            drawTicks: false
+                        },
+                        ticks: {
+                            font: {
+                                size: 9
+                            },
+                            padding: 10
+                        }
+                    }
+                }
+            }
+        });
+    });
+    /*]]>*/
+
+</script>
+
+</main>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-A3rJD856KowSb7dwlZdYEkO39Gagi7vIsF0jrRAoQmDKKtQBHUuLZ9AsSv4jD4Xa"
+        crossorigin="anonymous"></script>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
+
+</body>

--- a/src/main/resources/templates/dashboard/index.th.xml
+++ b/src/main/resources/templates/dashboard/index.th.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<thlogic>
+  <attr sel="head" th:replace="head :: head" />
+  <attr sel="#header" th:replace="header :: header" />
+  <attr sel="#footer" th:replace="footer :: footer" />
+
+  <attr sel="#start-date" th:value="${param.startDate}" />
+  <attr sel="#last-date" th:value="${param.lastDate}" />
+  <attr sel="#statistics_type_custom" th:href="@{'/dashboard/test'(startDate=${param.startDate}, lastDate=${param.lastDate})}" th:method="get" />
+  <attr sel="#default_dashboard" th:href="@{'/dashboard'(startDate=${param.startDate}, lastDate=${param.lastDate})}" th:method="get" />
+  <attr sel="#client_top_20_dashboard" th:href="@{'/dashboard/clients'(startDate=${param.startDate}, lastDate=${param.lastDate})}" th:method="get" />
+  <attr sel="#get-report" th:href="@{'/dashboard/report'(startDate=${param.startDate}, lastDate=${param.lastDate})}" th:method="get" />
+
+  <attr sel="#dashboard-statistics-info">
+      <attr sel="tbody" th:remove="all-but-first">
+        <attr sel="tr[0]" th:each="resultpage : ${resultpages}">
+          <attr sel="td.date" th:text="${resultpage.startDate}" />
+          <attr sel="td.spend" th:text="${resultpage.sSpend} + '원'" />
+          <attr sel="td.minusVAT" th:text="${resultpage.sMinusVAT} + '원'"/>
+          <attr sel="td.VAT" th:text="${resultpage.sVAT} + '원'"/>
+          <attr sel="td.commission" th:text="${resultpage.sCommission} + '원'"/>
+        </attr>
+      </attr>
+    </attr>
+
+  <attr sel="#pagination">
+    <attr sel="li[0]/a"
+          th:text="'previous'"
+          th:href="@{/dashboard(page=${resultpages.number - 1}, startDate=${param.startDate}, lastDate=${param.lastDate})}"
+          th:class="'page-link' + (${resultpages.number} <= 0 ? ' disabled' : '')"
+    />
+    <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
+      <attr sel="a"
+            th:text="${pageNumber + 1}"
+            th:href="@{/dashboard(page=${pageNumber}, startDate=${param.startDate}, lastDate=${param.lastDate})}"
+            th:class="'page-link' + (${pageNumber} == ${resultpages.number} ? ' disabled' : '')"
+      />
+    </attr>
+    <attr sel="li[2]/a"
+          th:text="'next'"
+          th:href="@{/dashboard(page=${resultpages.number + 1}, startDate=${param.startDate}, lastDate=${param.lastDate})}"
+          th:class="'page-link' + (${resultpages.number} >= ${resultpages.totalPages - 1} ? ' disabled' : '')"
+    />
+  </attr>
+</attr>
+</thlogic>

--- a/src/main/resources/templates/manage/campaign-form.html
+++ b/src/main/resources/templates/manage/campaign-form.html
@@ -58,7 +58,7 @@
           </a>
         </li>
         <li>
-          <a href="#" class="nav-link text-white">
+          <a href="/dashboard" class="nav-link text-white">
             <svg class="bi pe-none me-2" width="16" height="16">
               <use xlink:href="#people-circle"/>
             </svg>

--- a/src/main/resources/templates/manage/campaign.html
+++ b/src/main/resources/templates/manage/campaign.html
@@ -58,7 +58,7 @@
         </a>
       </li>
       <li>
-        <a href="#" class="nav-link text-white">
+        <a href="/dashboard" class="nav-link text-white">
           <svg class="bi pe-none me-2" width="16" height="16">
             <use xlink:href="#people-circle"/>
           </svg>

--- a/src/main/resources/templates/manage/creative-form.html
+++ b/src/main/resources/templates/manage/creative-form.html
@@ -48,7 +48,7 @@
             </a>
           </li>
           <li>
-            <a href="#" class="nav-link text-white">
+            <a href="/dashboard" class="nav-link text-white">
               <svg class="bi pe-none me-2" width="16" height="16"><use xlink:href="#people-circle"/></svg>
               대시보드
             </a>

--- a/src/main/resources/templates/manage/creative.html
+++ b/src/main/resources/templates/manage/creative.html
@@ -59,7 +59,7 @@
         </a>
       </li>
       <li>
-        <a href="#" class="nav-link text-white">
+        <a href="/dashboard" class="nav-link text-white">
           <svg class="bi pe-none me-2" width="16" height="16">
             <use xlink:href="#people-circle"/>
           </svg>

--- a/src/main/resources/templates/manage/index.html
+++ b/src/main/resources/templates/manage/index.html
@@ -59,7 +59,7 @@
         </a>
       </li>
       <li>
-        <a href="#" class="nav-link text-white">
+        <a href="/dashboard" class="nav-link text-white">
           <svg class="bi pe-none me-2" width="16" height="16">
             <use xlink:href="#people-circle"/>
           </svg>

--- a/src/main/resources/templates/manage/performance.html
+++ b/src/main/resources/templates/manage/performance.html
@@ -59,7 +59,7 @@
         </a>
       </li>
       <li>
-        <a href="#" class="nav-link text-white">
+        <a href="/dashboard" class="nav-link text-white">
           <svg class="bi pe-none me-2" width="16" height="16">
             <use xlink:href="#people-circle"/>
           </svg>


### PR DESCRIPTION
대시보드의 통계 기능을 구현하고 페이지를 생성한다.

* [x] 대시보드 페이지 구현
* [x] chart.js 테스트
* [x] 대시보드 통계 기능 구현
  * [x] 10/01 ~ 10/29 시 1~29일의 일일 전체 소진액 차트 (일 단위)
  * [x] ~~1월, 2월, 3월... 전체 소진액 차트 (월 단위)~~
  * [x] 상위 탑 10 광고주 소진액 차트 (기간 합계) + 차트 (전체)
 * [x] 대시보드 차트 데이터 보고서 다운로드 기능 구현

This closes #135 